### PR TITLE
Use /memory in compose agent volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
         target: /workspace
       - type: volume
         source: q15_memory
-        target: /workspace/.q15-memory
+        target: /memory
       - type: volume
         source: q15_skills
         target: /skills


### PR DESCRIPTION
Fixes #21

Update the Compose agent memory volume mount to use `/memory` so Compose matches the unified runtime memory path used by the agent config, README, and Kubernetes manifests.