### PR TITLE
docs: document persistent /nix volume in Compose README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ The Compose example uses:
 - a bind mount of this repo as `/workspace`
 - a named volume shared as `/memory`
 - a named volume for `/skills`
+- a named volume `q15_exec_nix_store` mounted at `/nix` for persistent executor package/store reuse across sessions
 - Docker secret files under
   [deploy/compose/secrets](/deploy/compose/secrets)
 
@@ -233,6 +234,7 @@ development example, so it bind-mounts this repo into `/workspace`. For long-run
 deployments, mount stack-owned persistent storage at `/workspace` instead and keep that same storage
 attached across restarts. That storage may start as an empty persistent volume or empty host
 directory; q15 does not require `/workspace` to be pre-populated before first startup.
+The `/nix` mount is intentionally persistent in long-running deployments and should not be treated as scratch space.
 
 Before using the stack for real, replace the placeholder values in:
 


### PR DESCRIPTION
### Motivation
- Make the Compose README explicit about the executor's persistent Nix store so operators know the exact volume name, mount path, and that it is intended to persist across restarts for package/store reuse. 

### Description
- Updated the **Local Docker Compose Stack** section in `README.md` to add a bullet documenting the named volume `q15_exec_nix_store` mounted at `/nix` and described its purpose as persistent executor package/store reuse across sessions, and added a short sentence clarifying that the `/nix` mount is intentionally persistent in long-running deployments and should not be treated as scratch space. 

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3c014d360832f8fb1cf720836ee27)