### PR TITLE
fix: report per-model errors when all models fail

### DIFF
--- a/systems/agent/internal/agent/engine.go
+++ b/systems/agent/internal/agent/engine.go
@@ -249,6 +249,10 @@ func (e *Engine) completeWithObserver(
 
 	var lastErr error
 	lastModelRef := ""
+	var modelErrors []struct {
+		ref string
+		err error
+	}
 	for attempt, modelRef := range plan.EligibleRefs {
 		lastModelRef = modelRef
 		emitRunEvent(ctx, observer, RunEvent{
@@ -280,10 +284,27 @@ func (e *Engine) completeWithObserver(
 			err,
 		)
 		lastErr = err
+		modelErrors = append(modelErrors, struct {
+			ref string
+			err error
+		}{modelRef, err})
 	}
 
 	if lastErr == nil {
 		return "", ModelClientResult{}, fmt.Errorf("no models configured")
+	}
+
+	if len(modelErrors) > 1 {
+		var parts []string
+		for _, me := range modelErrors {
+			parts = append(parts, fmt.Sprintf("  %s: %v", me.ref, me.err))
+		}
+		return lastModelRef, ModelClientResult{}, fmt.Errorf(
+			"all models failed (%v): %w\nper-model errors:\n%s",
+			plan.EligibleRefs,
+			lastErr,
+			strings.Join(parts, "\n"),
+		)
 	}
 	return lastModelRef, ModelClientResult{}, fmt.Errorf(
 		"all models failed (%v): %w",

--- a/systems/agent/internal/agent/engine_test.go
+++ b/systems/agent/internal/agent/engine_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/q15co/q15/systems/agent/internal/conversation"
@@ -85,6 +87,76 @@ func TestEngineRun_RequiresToolCallingWhenRequested(t *testing.T) {
 	}
 	if len(gotTools) != 1 || gotTools[0].Name != "echo" {
 		t.Fatalf("gotTools = %#v, want one echo tool", gotTools)
+	}
+}
+
+func TestEngineRun_AllModelsFailed_ReportsPerModelErrors(t *testing.T) {
+	model := &fakeModelClient{
+		complete: func(
+			_ context.Context,
+			model string,
+			_ []conversation.Message,
+			_ []ToolDefinition,
+		) (ModelClientResult, error) {
+			if model == "gpt-5.4" {
+				return ModelClientResult{}, errors.New("responses API error: internal server error")
+			}
+			return ModelClientResult{}, errors.New("messages parameter is illegal (code 1214)")
+		},
+	}
+
+	engine := NewEngine(model, nil, []string{"gpt-5.4", "glm-5-turbo"})
+	_, err := engine.Run(context.Background(), EngineRequest{
+		Messages: []conversation.Message{
+			conversation.SystemMessage("prompt"),
+			conversation.UserMessage("hello"),
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "per-model errors:") {
+		t.Fatalf("error should contain 'per-model errors:', got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "gpt-5.4:") {
+		t.Fatalf("error should mention gpt-5.4, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "glm-5-turbo:") {
+		t.Fatalf("error should mention glm-5-turbo, got: %s", errMsg)
+	}
+	// lastErr should still be unwrappable
+	if !strings.Contains(errMsg, "all models failed") {
+		t.Fatalf("error should contain 'all models failed', got: %s", errMsg)
+	}
+}
+
+func TestEngineRun_SingleModelFailed_NoPerModelSection(t *testing.T) {
+	model := &fakeModelClient{
+		results: []ModelClientResult{},
+		complete: func(
+			_ context.Context,
+			_ string,
+			_ []conversation.Message,
+			_ []ToolDefinition,
+		) (ModelClientResult, error) {
+			return ModelClientResult{}, errors.New("connection refused")
+		},
+	}
+
+	engine := NewEngine(model, nil, []string{"only-model"})
+	_, err := engine.Run(context.Background(), EngineRequest{
+		Messages: []conversation.Message{
+			conversation.SystemMessage("prompt"),
+			conversation.UserMessage("hello"),
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "per-model errors:") {
+		t.Fatalf("single model failure should not include per-model section, got: %s", errMsg)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #60

When the engine tries multiple models during fallback and all fail, it previously only reported the last model's error. This made it impossible to debug why earlier models (e.g. gpt-5.4) failed, since their errors were silently discarded.

## What changed

**** - In `completeWithObserver`, per-model errors are now collected into a slice. When 2+ models fail, the returned error message includes a `per-model errors:` section listing each model ref alongside its specific error. The last error is still wrapped via `%w` for backward compatibility.

**** - Added two tests:
- `TestEngineRun_AllModelsFailed_ReportsPerModelErrors`: verifies the per-model section appears with both model refs and errors
- `TestEngineRun_SingleModelFailed_NoPerModelSection`: verifies single-model failures are unchanged

## Example output (before vs after)

**Before:**
```
all models failed ([gpt-5.4 glm-5-turbo]): chat completion: POST "...": 400 Bad Request {"code":"1214","message":"The messages parameter is illegal."}
```

**After:**
```
all models failed ([gpt-5.4 glm-5-turbo]): chat completion: POST "...": 400 Bad Request {"code":"1214","message":"The messages parameter is illegal."}
per-model errors:
  gpt-5.4: responses API error: internal server error
  glm-5-turbo: messages parameter is illegal (code 1214)
```

## Testing

All 34 tests pass (including 2 new ones).