### PR TITLE
[codex] Add semantic extraction checkpoint

### DIFF
--- a/systems/agent/internal/app/runtime_entrypoints_test.go
+++ b/systems/agent/internal/app/runtime_entrypoints_test.go
@@ -31,6 +31,13 @@ func (s *spyRuntimeStore) LoadLatestMessages(
 	return nil, nil
 }
 
+func (s *spyRuntimeStore) LoadMessagesSinceSeq(
+	context.Context,
+	int64,
+) ([]conversation.Message, error) {
+	return nil, nil
+}
+
 func (s *spyRuntimeStore) LoadLastUserTimestamp(
 	context.Context,
 ) (time.Time, bool, error) {
@@ -85,6 +92,12 @@ func (s *spyRuntimeStore) LoadConsolidationCheckpoint(
 	return cognition.ConsolidationCheckpoint{}, nil
 }
 
+func (s *spyRuntimeStore) LoadSemanticExtractionCheckpoint(
+	context.Context,
+) (cognition.SemanticExtractionCheckpoint, error) {
+	return cognition.SemanticExtractionCheckpoint{}, nil
+}
+
 func (s *spyRuntimeStore) LoadJobState(
 	context.Context,
 	string,
@@ -105,6 +118,13 @@ func (s *spyRuntimeStore) StoreConsolidationCheckpoint(
 	cognition.ConsolidationCheckpoint,
 ) (cognition.ConsolidationCheckpoint, error) {
 	return cognition.ConsolidationCheckpoint{}, nil
+}
+
+func (s *spyRuntimeStore) StoreSemanticExtractionCheckpoint(
+	context.Context,
+	cognition.SemanticExtractionCheckpoint,
+) (cognition.SemanticExtractionCheckpoint, error) {
+	return cognition.SemanticExtractionCheckpoint{}, nil
 }
 
 func (s *spyRuntimeStore) AppendRunRecord(

--- a/systems/agent/internal/app/runtime_store.go
+++ b/systems/agent/internal/app/runtime_store.go
@@ -42,6 +42,13 @@ func (s *runtimeStore) LoadLatestMessages(
 	return s.memory.LoadLatestMessages(ctx, turns)
 }
 
+func (s *runtimeStore) LoadMessagesSinceSeq(
+	ctx context.Context,
+	afterSeq int64,
+) ([]conversation.Message, error) {
+	return s.memory.LoadMessagesSinceSeq(ctx, afterSeq)
+}
+
 func (s *runtimeStore) LoadLastUserTimestamp(
 	ctx context.Context,
 ) (time.Time, bool, error) {
@@ -122,6 +129,12 @@ func (s *runtimeStore) LoadConsolidationCheckpoint(
 	return s.memory.LoadConsolidationCheckpoint(ctx)
 }
 
+func (s *runtimeStore) LoadSemanticExtractionCheckpoint(
+	ctx context.Context,
+) (cognition.SemanticExtractionCheckpoint, error) {
+	return s.memory.LoadSemanticExtractionCheckpoint(ctx)
+}
+
 func (s *runtimeStore) LoadJobState(
 	ctx context.Context,
 	jobType string,
@@ -142,6 +155,13 @@ func (s *runtimeStore) StoreConsolidationCheckpoint(
 	checkpoint cognition.ConsolidationCheckpoint,
 ) (cognition.ConsolidationCheckpoint, error) {
 	return s.memory.StoreConsolidationCheckpoint(ctx, checkpoint)
+}
+
+func (s *runtimeStore) StoreSemanticExtractionCheckpoint(
+	ctx context.Context,
+	checkpoint cognition.SemanticExtractionCheckpoint,
+) (cognition.SemanticExtractionCheckpoint, error) {
+	return s.memory.StoreSemanticExtractionCheckpoint(ctx, checkpoint)
 }
 
 func (s *runtimeStore) AppendRunRecord(ctx context.Context, record cognition.RunRecord) error {

--- a/systems/agent/internal/cognition/controller.go
+++ b/systems/agent/internal/cognition/controller.go
@@ -78,6 +78,15 @@ type ConsolidationCheckpoint struct {
 	UpdatedAt              time.Time `json:"updated_at,omitempty"`
 }
 
+// SemanticExtractionCheckpoint records the last episodic turn boundary that has
+// been successfully processed by semantic-memory extraction.
+type SemanticExtractionCheckpoint struct {
+	LastExtractedTurnID string    `json:"last_extracted_turn_id,omitempty"`
+	LastExtractedSeq    int64     `json:"last_extracted_seq,omitempty"`
+	LastExtractedAt     time.Time `json:"last_extracted_at,omitempty"`
+	UpdatedAt           time.Time `json:"updated_at,omitempty"`
+}
+
 // JobState tracks persisted trigger/controller state for one job type.
 type JobState struct {
 	LastRunAt           time.Time            `json:"last_run_at,omitempty"`
@@ -127,6 +136,10 @@ type ControllerStore interface {
 		context.Context,
 		ConsolidationCheckpoint,
 	) (ConsolidationCheckpoint, error)
+	StoreSemanticExtractionCheckpoint(
+		context.Context,
+		SemanticExtractionCheckpoint,
+	) (SemanticExtractionCheckpoint, error)
 	AppendRunRecord(context.Context, RunRecord) error
 }
 
@@ -484,14 +497,30 @@ func (c *Controller) runPending(ctx context.Context, pending pendingRun) error {
 	}
 
 	result, runErr := c.runner.Run(ctx, pending.job.newJob(), nil)
-	var checkpoint ConsolidationCheckpoint
+	var consolidationCheckpoint ConsolidationCheckpoint
 	if runErr == nil && shouldAdvanceConsolidationCheckpoint(pending.job.jobType) {
-		checkpoint, runErr = c.store.StoreConsolidationCheckpoint(ctx, ConsolidationCheckpoint{
-			LastConsolidatedSeq: pending.headSeq,
-			LastConsolidatedAt:  pending.headAt,
-		})
+		consolidationCheckpoint, runErr = c.store.StoreConsolidationCheckpoint(
+			ctx,
+			ConsolidationCheckpoint{
+				LastConsolidatedSeq: pending.headSeq,
+				LastConsolidatedAt:  pending.headAt,
+			},
+		)
 		if runErr != nil {
 			runErr = fmt.Errorf("store consolidation checkpoint: %w", runErr)
+		}
+	}
+	var semanticExtractionCheckpoint SemanticExtractionCheckpoint
+	if runErr == nil && shouldAdvanceSemanticExtractionCheckpoint(pending.job.jobType) {
+		semanticExtractionCheckpoint, runErr = c.store.StoreSemanticExtractionCheckpoint(
+			ctx,
+			SemanticExtractionCheckpoint{
+				LastExtractedSeq: pending.headSeq,
+				LastExtractedAt:  pending.headAt,
+			},
+		)
+		if runErr != nil {
+			runErr = fmt.Errorf("store semantic extraction checkpoint: %w", runErr)
 		}
 	}
 	finishedAt := time.Now().UTC()
@@ -532,7 +561,14 @@ func (c *Controller) runPending(ctx context.Context, pending pendingRun) error {
 	} else {
 		record.Summary = strings.TrimSpace(result.Summary)
 		record.Metadata = cloneRunRecordMetadata(result.Metadata)
-		record.Metadata = withConsolidationCheckpointMetadata(record.Metadata, checkpoint)
+		record.Metadata = withConsolidationCheckpointMetadata(
+			record.Metadata,
+			consolidationCheckpoint,
+		)
+		record.Metadata = withSemanticExtractionCheckpointMetadata(
+			record.Metadata,
+			semanticExtractionCheckpoint,
+		)
 		record.ModelRef = result.ModelRef
 	}
 	if err := c.store.AppendRunRecord(ctx, record); err != nil {
@@ -612,6 +648,33 @@ func withConsolidationCheckpointMetadata(
 	return metadata
 }
 
+func withSemanticExtractionCheckpointMetadata(
+	metadata map[string]string,
+	checkpoint SemanticExtractionCheckpoint,
+) map[string]string {
+	if checkpoint.LastExtractedSeq == 0 &&
+		strings.TrimSpace(checkpoint.LastExtractedTurnID) == "" &&
+		checkpoint.LastExtractedAt.IsZero() {
+		return metadata
+	}
+	if metadata == nil {
+		metadata = make(map[string]string)
+	}
+	metadata["semantic_extraction_checkpoint_seq"] = fmt.Sprintf(
+		"%d",
+		checkpoint.LastExtractedSeq,
+	)
+	if turnID := strings.TrimSpace(checkpoint.LastExtractedTurnID); turnID != "" {
+		metadata["semantic_extraction_checkpoint_turn_id"] = turnID
+	}
+	if !checkpoint.LastExtractedAt.IsZero() {
+		metadata["semantic_extraction_checkpoint_at"] = checkpoint.LastExtractedAt.UTC().Format(
+			time.RFC3339Nano,
+		)
+	}
+	return metadata
+}
+
 func (c *Controller) latestDue(
 	rule compiledScheduleRule,
 	state JobState,
@@ -682,6 +745,10 @@ func shouldEvaluateStateRules(state JobState, headSeq int64) bool {
 
 func shouldAdvanceConsolidationCheckpoint(jobType string) bool {
 	return strings.TrimSpace(jobType) == workingMemoryConsolidationJobType
+}
+
+func shouldAdvanceSemanticExtractionCheckpoint(jobType string) bool {
+	return strings.TrimSpace(jobType) == semanticMemoryExtractionJobType
 }
 
 func syncDirtyState(state JobState, headSeq int64, headAt time.Time) (JobState, bool) {

--- a/systems/agent/internal/cognition/controller_test.go
+++ b/systems/agent/internal/cognition/controller_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 type fakeControllerStore struct {
-	mu         sync.Mutex
-	headSeq    int64
-	headAt     time.Time
-	states     map[string]JobState
-	records    []RunRecord
-	checkpoint ConsolidationCheckpoint
+	mu                           sync.Mutex
+	headSeq                      int64
+	headAt                       time.Time
+	states                       map[string]JobState
+	records                      []RunRecord
+	checkpoint                   ConsolidationCheckpoint
+	semanticExtractionCheckpoint SemanticExtractionCheckpoint
 }
 
 func newFakeControllerStore() *fakeControllerStore {
@@ -80,6 +81,33 @@ func (s *fakeControllerStore) StoreConsolidationCheckpoint(
 	return checkpoint, nil
 }
 
+func (s *fakeControllerStore) StoreSemanticExtractionCheckpoint(
+	_ context.Context,
+	checkpoint SemanticExtractionCheckpoint,
+) (SemanticExtractionCheckpoint, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	checkpoint.LastExtractedSeq = max(0, checkpoint.LastExtractedSeq)
+	if checkpoint.LastExtractedSeq > 0 {
+		checkpoint.LastExtractedTurnID = fmt.Sprintf(
+			"turn-%020d",
+			checkpoint.LastExtractedSeq,
+		)
+		if checkpoint.LastExtractedAt.IsZero() {
+			checkpoint.LastExtractedAt = s.headAt
+		}
+	} else {
+		checkpoint.LastExtractedTurnID = ""
+		checkpoint.LastExtractedAt = time.Time{}
+	}
+	if checkpoint.UpdatedAt.IsZero() {
+		checkpoint.UpdatedAt = time.Now().UTC()
+	}
+	s.semanticExtractionCheckpoint = checkpoint
+	return checkpoint, nil
+}
+
 func (s *fakeControllerStore) AppendRunRecord(_ context.Context, record RunRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -112,6 +140,12 @@ func (s *fakeControllerStore) consolidationCheckpoint() ConsolidationCheckpoint 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.checkpoint
+}
+
+func (s *fakeControllerStore) semanticCheckpoint() SemanticExtractionCheckpoint {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.semanticExtractionCheckpoint
 }
 
 func waitFor(t *testing.T, timeout time.Duration, fn func() bool) {
@@ -595,6 +629,94 @@ func TestControllerPreservesDirtyStateWhenHeadAdvancesDuringRun(t *testing.T) {
 	if got, want := records[0].Metadata["consolidation_checkpoint_at"], initialHeadAt.Format(time.RFC3339Nano); got != want {
 		t.Fatalf("run metadata[consolidation_checkpoint_at] = %q, want %q", got, want)
 	}
+	if checkpoint := store.semanticCheckpoint(); checkpoint != (SemanticExtractionCheckpoint{}) {
+		t.Fatalf("semantic checkpoint = %#v, want zero value", checkpoint)
+	}
+}
+
+func TestControllerSuccessfulSemanticRunAdvancesSemanticExtractionCheckpoint(t *testing.T) {
+	store := newFakeControllerStore()
+	initialHeadAt := time.Date(2026, time.April, 7, 8, 9, 10, 0, time.UTC)
+	store.setHead(3, initialHeadAt)
+
+	controller := newControllerForTest(t, store, JobRegistration{
+		NewJob: func() JobDefinition {
+			return fakeJob{
+				jobType: semanticMemoryExtractionJobType,
+				build: func(context.Context, ContextLoader) (Spec, error) {
+					return Spec{
+						Objective:          "Extract semantic memory.",
+						CompletionContract: "Return `status: ok`.",
+					}, nil
+				},
+				apply: func(context.Context, ContextLoader, JobOutput) (ParsedResult, error) {
+					return ParsedResult{Summary: "semantic"}, nil
+				},
+			}
+		},
+		Policy: TriggerPolicy{
+			State: []StateRule{{
+				ID: "dirty",
+				Evaluate: func(_ context.Context, _ Snapshot, state JobState) (bool, string, error) {
+					return state.DirtySinceSeq > 0, "dirty", nil
+				},
+			}},
+		},
+	})
+	controller.started = time.Now().UTC()
+
+	pending, ok, err := controller.nextPendingRun(context.Background(), false, false, true)
+	if err != nil {
+		t.Fatalf("nextPendingRun() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("nextPendingRun() ok = false, want true")
+	}
+	if err := controller.runPending(context.Background(), pending); err != nil {
+		t.Fatalf("runPending() error = %v", err)
+	}
+
+	checkpoint := store.semanticCheckpoint()
+	if checkpoint.LastExtractedSeq != 3 {
+		t.Fatalf("checkpoint.LastExtractedSeq = %d, want 3", checkpoint.LastExtractedSeq)
+	}
+	if checkpoint.LastExtractedTurnID != "turn-00000000000000000003" {
+		t.Fatalf(
+			"checkpoint.LastExtractedTurnID = %q, want %q",
+			checkpoint.LastExtractedTurnID,
+			"turn-00000000000000000003",
+		)
+	}
+	if !checkpoint.LastExtractedAt.Equal(initialHeadAt) {
+		t.Fatalf(
+			"checkpoint.LastExtractedAt = %s, want %s",
+			checkpoint.LastExtractedAt,
+			initialHeadAt,
+		)
+	}
+	if checkpoint := store.consolidationCheckpoint(); checkpoint != (ConsolidationCheckpoint{}) {
+		t.Fatalf("consolidation checkpoint = %#v, want zero value", checkpoint)
+	}
+
+	records := store.runRecords()
+	if len(records) != 1 {
+		t.Fatalf("run records len = %d, want 1", len(records))
+	}
+	if got, want := records[0].Metadata["semantic_extraction_checkpoint_seq"], "3"; got != want {
+		t.Fatalf("run metadata[semantic_extraction_checkpoint_seq] = %q, want %q", got, want)
+	}
+	if got, want := records[0].Metadata["semantic_extraction_checkpoint_turn_id"], "turn-00000000000000000003"; got != want {
+		t.Fatalf("run metadata[semantic_extraction_checkpoint_turn_id] = %q, want %q", got, want)
+	}
+	if got, want := records[0].Metadata["semantic_extraction_checkpoint_at"], initialHeadAt.Format(time.RFC3339Nano); got != want {
+		t.Fatalf("run metadata[semantic_extraction_checkpoint_at] = %q, want %q", got, want)
+	}
+	if _, ok := records[0].Metadata["consolidation_checkpoint_seq"]; ok {
+		t.Fatalf(
+			"run metadata unexpectedly included consolidation checkpoint: %#v",
+			records[0].Metadata,
+		)
+	}
 }
 
 func TestControllerFailedWorkingMemoryRunLeavesCheckpointUnchanged(t *testing.T) {
@@ -643,6 +765,52 @@ func TestControllerFailedWorkingMemoryRunLeavesCheckpointUnchanged(t *testing.T)
 	}
 }
 
+func TestControllerFailedSemanticRunLeavesCheckpointUnchanged(t *testing.T) {
+	store := newFakeControllerStore()
+	store.setHead(1, time.Now().UTC())
+
+	controller := newControllerForTest(t, store, JobRegistration{
+		NewJob: func() JobDefinition {
+			return fakeJob{
+				jobType: semanticMemoryExtractionJobType,
+				build: func(context.Context, ContextLoader) (Spec, error) {
+					return Spec{
+						Objective:          "Fail semantic extraction.",
+						CompletionContract: "Return `status: ok`.",
+					}, nil
+				},
+				apply: func(context.Context, ContextLoader, JobOutput) (ParsedResult, error) {
+					return ParsedResult{}, errors.New("apply failed")
+				},
+			}
+		},
+		Policy: TriggerPolicy{
+			State: []StateRule{{
+				ID: "dirty",
+				Evaluate: func(_ context.Context, _ Snapshot, state JobState) (bool, string, error) {
+					return state.DirtySinceSeq > 0, "dirty", nil
+				},
+			}},
+		},
+	})
+	controller.started = time.Now().UTC()
+
+	pending, ok, err := controller.nextPendingRun(context.Background(), false, false, true)
+	if err != nil {
+		t.Fatalf("nextPendingRun() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("nextPendingRun() ok = false, want true")
+	}
+	if err := controller.runPending(context.Background(), pending); err != nil {
+		t.Fatalf("runPending() error = %v", err)
+	}
+
+	if checkpoint := store.semanticCheckpoint(); checkpoint != (SemanticExtractionCheckpoint{}) {
+		t.Fatalf("semantic checkpoint = %#v, want zero value", checkpoint)
+	}
+}
+
 func TestControllerVerificationRunDoesNotAdvanceCheckpoint(t *testing.T) {
 	store := newFakeControllerStore()
 	store.setHead(1, time.Now().UTC())
@@ -687,6 +855,9 @@ func TestControllerVerificationRunDoesNotAdvanceCheckpoint(t *testing.T) {
 	if checkpoint := store.consolidationCheckpoint(); checkpoint != (ConsolidationCheckpoint{}) {
 		t.Fatalf("checkpoint = %#v, want zero value", checkpoint)
 	}
+	if checkpoint := store.semanticCheckpoint(); checkpoint != (SemanticExtractionCheckpoint{}) {
+		t.Fatalf("semantic checkpoint = %#v, want zero value", checkpoint)
+	}
 	records := store.runRecords()
 	if len(records) != 1 {
 		t.Fatalf("run records len = %d, want 1", len(records))
@@ -694,6 +865,12 @@ func TestControllerVerificationRunDoesNotAdvanceCheckpoint(t *testing.T) {
 	if _, ok := records[0].Metadata["consolidation_checkpoint_seq"]; ok {
 		t.Fatalf(
 			"run metadata unexpectedly included consolidation checkpoint: %#v",
+			records[0].Metadata,
+		)
+	}
+	if _, ok := records[0].Metadata["semantic_extraction_checkpoint_seq"]; ok {
+		t.Fatalf(
+			"run metadata unexpectedly included semantic checkpoint: %#v",
 			records[0].Metadata,
 		)
 	}

--- a/systems/agent/internal/cognition/runner.go
+++ b/systems/agent/internal/cognition/runner.go
@@ -19,8 +19,10 @@ type ContextLoader interface {
 	LoadSkillCatalog(ctx context.Context) (agent.SkillCatalog, error)
 	LoadRecentMessages(ctx context.Context, turns int) ([]conversation.Message, error)
 	LoadLatestMessages(ctx context.Context, turns int) ([]conversation.Message, error)
+	LoadMessagesSinceSeq(ctx context.Context, afterSeq int64) ([]conversation.Message, error)
 	LoadHead(ctx context.Context) (int64, time.Time, error)
 	LoadConsolidationCheckpoint(ctx context.Context) (ConsolidationCheckpoint, error)
+	LoadSemanticExtractionCheckpoint(ctx context.Context) (SemanticExtractionCheckpoint, error)
 	LoadCognitionArtifact(ctx context.Context, relativePath string) (Artifact, error)
 	StoreCognitionArtifact(ctx context.Context, artifact Artifact) error
 }

--- a/systems/agent/internal/cognition/runner_test.go
+++ b/systems/agent/internal/cognition/runner_test.go
@@ -106,6 +106,13 @@ func (s *spyLoader) LoadLatestMessages(
 	return nil, nil
 }
 
+func (s *spyLoader) LoadMessagesSinceSeq(
+	context.Context,
+	int64,
+) ([]conversation.Message, error) {
+	return nil, nil
+}
+
 func (s *spyLoader) LoadHead(context.Context) (int64, time.Time, error) {
 	return 0, time.Time{}, nil
 }
@@ -114,6 +121,12 @@ func (s *spyLoader) LoadConsolidationCheckpoint(
 	context.Context,
 ) (ConsolidationCheckpoint, error) {
 	return ConsolidationCheckpoint{}, nil
+}
+
+func (s *spyLoader) LoadSemanticExtractionCheckpoint(
+	context.Context,
+) (SemanticExtractionCheckpoint, error) {
+	return SemanticExtractionCheckpoint{}, nil
 }
 
 func (s *spyLoader) LoadCognitionArtifact(

--- a/systems/agent/internal/cognition/semantic_memory_job.go
+++ b/systems/agent/internal/cognition/semantic_memory_job.go
@@ -80,9 +80,34 @@ func (semanticMemoryExtractionJob) Build(
 	if err != nil {
 		return Spec{}, fmt.Errorf("load verification review artifact: %w", err)
 	}
-	recentMessages, err := loader.LoadLatestMessages(ctx, semanticMemoryRecentTurns)
+	semanticCheckpoint, err := loader.LoadSemanticExtractionCheckpoint(ctx)
 	if err != nil {
-		return Spec{}, fmt.Errorf("load latest messages: %w", err)
+		return Spec{}, fmt.Errorf("load semantic extraction checkpoint: %w", err)
+	}
+	var recentMessages []conversation.Message
+	var transcriptStatus string
+	if semanticCheckpoint.LastExtractedSeq > 0 {
+		recentMessages, err = loader.LoadMessagesSinceSeq(
+			ctx,
+			semanticCheckpoint.LastExtractedSeq,
+		)
+		if err != nil {
+			return Spec{}, fmt.Errorf("load messages since semantic extraction checkpoint: %w", err)
+		}
+		transcriptStatus = renderSemanticExtractionTranscriptScope(
+			semanticCheckpoint,
+			len(recentMessages),
+		)
+	} else {
+		recentMessages, err = loader.LoadLatestMessages(ctx, semanticMemoryRecentTurns)
+		if err != nil {
+			return Spec{}, fmt.Errorf("load latest messages: %w", err)
+		}
+		transcriptStatus = renderTranscriptScopeWithPolicy(
+			"selected by the initial semantic replay fallback window independent of the working-memory consolidation checkpoint",
+			semanticMemoryRecentTurns,
+			len(recentMessages),
+		)
 	}
 
 	semanticFiles := semanticMemoryContentMap(semantic)
@@ -114,11 +139,6 @@ func (semanticMemoryExtractionJob) Build(
 		verificationAttrs["present"] = "true"
 	}
 
-	transcriptStatus := renderTranscriptScopeWithPolicy(
-		"selected by a semantic replay window independent of the working-memory consolidation checkpoint",
-		semanticMemoryRecentTurns,
-		len(recentMessages),
-	)
 	transcriptArtifact := renderTranscriptArtifact(recentMessages)
 
 	return Spec{
@@ -323,6 +343,23 @@ func shouldRunSemanticMemoryExtraction(
 		dirtyTurns,
 		state.DirtySinceSeq,
 		snapshot.HeadLastSeq,
+	)
+}
+
+func renderSemanticExtractionTranscriptScope(
+	checkpoint SemanticExtractionCheckpoint,
+	loadedMessages int,
+) string {
+	if loadedMessages == 0 {
+		return "No transcript messages were loaded for this run."
+	}
+	checkpointSeq := max(0, checkpoint.LastExtractedSeq)
+	return renderPromptLines(
+		fmt.Sprintf(
+			"A semantic extraction replay slice of episodic history after semantic extraction checkpoint seq %d is included below as a transcript artifact.",
+			checkpointSeq,
+		),
+		"Treat it as historical evidence for newly unextracted or still-relevant context, not as the full transcript.",
 	)
 }
 

--- a/systems/agent/internal/cognition/semantic_memory_job_test.go
+++ b/systems/agent/internal/cognition/semantic_memory_job_test.go
@@ -12,14 +12,17 @@ import (
 )
 
 type semanticMemoryJobLoader struct {
-	semantic          agent.SemanticMemory
-	working           agent.WorkingMemory
-	artifacts         map[string]Artifact
-	recent            []conversation.Message
-	loadSemanticCalls int
-	loadLatestTurns   int
-	loadRecentTurns   int
-	loadArtifacts     []string
+	semantic                agent.SemanticMemory
+	working                 agent.WorkingMemory
+	artifacts               map[string]Artifact
+	recent                  []conversation.Message
+	checkpoint              SemanticExtractionCheckpoint
+	loadSemanticCalls       int
+	loadLatestTurns         int
+	loadRecentTurns         int
+	loadMessagesSinceSeqSeq int64
+	loadCheckpointCalls     int
+	loadArtifacts           []string
 }
 
 func (l *semanticMemoryJobLoader) LoadCoreMemory(context.Context) (agent.CoreMemory, error) {
@@ -57,6 +60,14 @@ func (l *semanticMemoryJobLoader) LoadLatestMessages(
 	return conversation.CloneMessages(l.recent), nil
 }
 
+func (l *semanticMemoryJobLoader) LoadMessagesSinceSeq(
+	_ context.Context,
+	afterSeq int64,
+) ([]conversation.Message, error) {
+	l.loadMessagesSinceSeqSeq = afterSeq
+	return conversation.CloneMessages(l.recent), nil
+}
+
 func (l *semanticMemoryJobLoader) LoadHead(context.Context) (int64, time.Time, error) {
 	return 0, time.Time{}, nil
 }
@@ -65,6 +76,13 @@ func (l *semanticMemoryJobLoader) LoadConsolidationCheckpoint(
 	context.Context,
 ) (ConsolidationCheckpoint, error) {
 	return ConsolidationCheckpoint{}, nil
+}
+
+func (l *semanticMemoryJobLoader) LoadSemanticExtractionCheckpoint(
+	context.Context,
+) (SemanticExtractionCheckpoint, error) {
+	l.loadCheckpointCalls++
+	return l.checkpoint, nil
 }
 
 func (l *semanticMemoryJobLoader) LoadCognitionArtifact(
@@ -209,6 +227,12 @@ func TestSemanticMemoryExtractionBuildLoadsSemanticWorkingVerificationAndTranscr
 	if got, want := loader.loadRecentTurns, 0; got != want {
 		t.Fatalf("LoadRecentMessages turns = %d, want %d", got, want)
 	}
+	if got, want := loader.loadMessagesSinceSeqSeq, int64(0); got != want {
+		t.Fatalf("LoadMessagesSinceSeq seq = %d, want %d", got, want)
+	}
+	if got, want := loader.loadCheckpointCalls, 1; got != want {
+		t.Fatalf("LoadSemanticExtractionCheckpoint calls = %d, want %d", got, want)
+	}
 	if got, want := len(loader.loadArtifacts), 1; got != want {
 		t.Fatalf("LoadCognitionArtifact calls = %d, want %d", got, want)
 	}
@@ -260,13 +284,76 @@ func TestSemanticMemoryExtractionBuildLoadsSemanticWorkingVerificationAndTranscr
 		"If a durable fact or preference is explicit and useful across future sessions, prefer promoting it rather than leaving it only in working memory.",
 		"Do not copy transcript detail or verification-review prose verbatim into semantic memory.",
 		"Run a cross-file de-duplication pass: remove fact side clauses from preferences.md and preference phrasing from facts.md before finalizing.",
-		"A bounded replay slice of episodic history, selected by a semantic replay window independent of the working-memory consolidation checkpoint and capped at 32 turns, is included below as a transcript artifact.",
+		"A bounded replay slice of episodic history, selected by the initial semantic replay fallback window independent of the working-memory consolidation checkpoint and capped at 32 turns, is included below as a transcript artifact.",
 		`<message_meta day_of_week_local="Sunday" timestamp_local="20260412T101112+0200" since_prev_user_message="3m42s"/>`,
 		"Remove unsupported durable claims.",
 	} {
 		if !contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)
 		}
+	}
+}
+
+func TestSemanticMemoryExtractionBuildUsesSemanticCheckpointReplay(t *testing.T) {
+	t.Parallel()
+
+	loader := &semanticMemoryJobLoader{
+		checkpoint: SemanticExtractionCheckpoint{LastExtractedSeq: 7},
+		semantic: agent.SemanticMemory{
+			Files: []agent.SemanticMemoryFile{
+				{
+					RelativePath: semanticFactsRelativePath,
+					Content:      "# Semantic Facts\n\n## Confirmed Facts\n\n- None\n\n## Grounded Inferences\n\n- None\n",
+				},
+				{
+					RelativePath: semanticPreferencesRelativePath,
+					Content:      "# Semantic Preferences\n\n## User Preferences\n\n- None\n\n## Collaboration Preferences\n\n- None\n",
+				},
+				{
+					RelativePath: semanticProjectsRelativePath,
+					Content:      "# Semantic Projects\n\n## Active Projects\n\n- None\n\n## Durable Project Knowledge\n\n- None\n",
+				},
+			},
+		},
+		working: agent.WorkingMemory{
+			RelativePath: workingMemoryRelativePath,
+			Content:      "# Working Memory\n\n## Active Tasks\n\n- None\n",
+		},
+		recent: []conversation.Message{
+			conversation.UserMessage("New durable preference after checkpoint."),
+			conversation.AssistantMessage(conversation.Text("Noted.", "")),
+		},
+	}
+
+	spec, err := NewSemanticMemoryExtractionRegistration().NewJob().Build(
+		context.Background(),
+		loader,
+	)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got, want := loader.loadCheckpointCalls, 1; got != want {
+		t.Fatalf("LoadSemanticExtractionCheckpoint calls = %d, want %d", got, want)
+	}
+	if got, want := loader.loadMessagesSinceSeqSeq, int64(7); got != want {
+		t.Fatalf("LoadMessagesSinceSeq seq = %d, want %d", got, want)
+	}
+	if got, want := loader.loadLatestTurns, 0; got != want {
+		t.Fatalf("LoadLatestMessages turns = %d, want %d", got, want)
+	}
+
+	prompt, err := renderPrompt(semanticMemoryExtractionJobType, spec)
+	if err != nil {
+		t.Fatalf("renderPrompt() error = %v", err)
+	}
+	if !contains(
+		prompt,
+		"A semantic extraction replay slice of episodic history after semantic extraction checkpoint seq 7 is included below as a transcript artifact.",
+	) {
+		t.Fatalf("prompt missing semantic checkpoint replay scope:\n%s", prompt)
+	}
+	if contains(prompt, "capped at 32 turns") {
+		t.Fatalf("prompt unexpectedly described checkpoint replay as capped:\n%s", prompt)
 	}
 }
 

--- a/systems/agent/internal/cognition/verification_job_test.go
+++ b/systems/agent/internal/cognition/verification_job_test.go
@@ -56,6 +56,13 @@ func (l *verificationJobLoader) LoadLatestMessages(
 	return nil, nil
 }
 
+func (l *verificationJobLoader) LoadMessagesSinceSeq(
+	context.Context,
+	int64,
+) ([]conversation.Message, error) {
+	return nil, nil
+}
+
 func (l *verificationJobLoader) LoadHead(context.Context) (int64, time.Time, error) {
 	return l.headSeq, l.headUpdatedAt, nil
 }
@@ -64,6 +71,12 @@ func (l *verificationJobLoader) LoadConsolidationCheckpoint(
 	context.Context,
 ) (ConsolidationCheckpoint, error) {
 	return l.checkpoint, nil
+}
+
+func (l *verificationJobLoader) LoadSemanticExtractionCheckpoint(
+	context.Context,
+) (SemanticExtractionCheckpoint, error) {
+	return SemanticExtractionCheckpoint{}, nil
 }
 
 func (l *verificationJobLoader) LoadCognitionArtifact(

--- a/systems/agent/internal/cognition/working_memory_job_test.go
+++ b/systems/agent/internal/cognition/working_memory_job_test.go
@@ -54,6 +54,13 @@ func (l *workingMemoryJobLoader) LoadLatestMessages(
 	return nil, nil
 }
 
+func (l *workingMemoryJobLoader) LoadMessagesSinceSeq(
+	context.Context,
+	int64,
+) ([]conversation.Message, error) {
+	return nil, nil
+}
+
 func (l *workingMemoryJobLoader) LoadHead(context.Context) (int64, time.Time, error) {
 	return 0, time.Time{}, nil
 }
@@ -62,6 +69,12 @@ func (l *workingMemoryJobLoader) LoadConsolidationCheckpoint(
 	context.Context,
 ) (ConsolidationCheckpoint, error) {
 	return ConsolidationCheckpoint{}, nil
+}
+
+func (l *workingMemoryJobLoader) LoadSemanticExtractionCheckpoint(
+	context.Context,
+) (SemanticExtractionCheckpoint, error) {
+	return SemanticExtractionCheckpoint{}, nil
 }
 
 func (l *workingMemoryJobLoader) LoadCognitionArtifact(

--- a/systems/agent/internal/memory/cognition_store.go
+++ b/systems/agent/internal/memory/cognition_store.go
@@ -116,6 +116,23 @@ func (s *Store) LoadConsolidationCheckpoint(
 	return consolidationCheckpointStateToCognition(checkpoint), nil
 }
 
+// LoadSemanticExtractionCheckpoint returns the current persisted semantic-memory
+// extraction checkpoint.
+func (s *Store) LoadSemanticExtractionCheckpoint(
+	ctx context.Context,
+) (cognition.SemanticExtractionCheckpoint, error) {
+	_ = ctx
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	checkpoint, err := s.readSemanticExtractionCheckpoint()
+	if err != nil {
+		return cognition.SemanticExtractionCheckpoint{}, err
+	}
+	return semanticExtractionCheckpointStateToCognition(checkpoint), nil
+}
+
 // StoreConsolidationCheckpoint persists the last successful working-memory
 // consolidation boundary used by checkpoint-aware transcript replay.
 func (s *Store) StoreConsolidationCheckpoint(
@@ -167,6 +184,63 @@ func (s *Store) StoreConsolidationCheckpoint(
 		)
 	}
 	return consolidationCheckpointStateToCognition(state), nil
+}
+
+// StoreSemanticExtractionCheckpoint persists the last successful semantic
+// extraction boundary used by semantic checkpoint-aware transcript replay.
+func (s *Store) StoreSemanticExtractionCheckpoint(
+	ctx context.Context,
+	checkpoint cognition.SemanticExtractionCheckpoint,
+) (cognition.SemanticExtractionCheckpoint, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state := semanticExtractionCheckpointStateFromCognition(checkpoint)
+
+	if state.LastExtractedSeq > 0 {
+		turn, ok, err := s.findTurnBySeq(state.LastExtractedSeq)
+		if err != nil {
+			return cognition.SemanticExtractionCheckpoint{}, err
+		}
+		if !ok {
+			return cognition.SemanticExtractionCheckpoint{}, fmt.Errorf(
+				"semantic extraction checkpoint seq %d not found in turn history",
+				state.LastExtractedSeq,
+			)
+		}
+		state.LastExtractedTurnID = strings.TrimSpace(turn.ID)
+		state.LastExtractedAt = turn.CreatedAt.UTC()
+	} else {
+		state.LastExtractedTurnID = ""
+		state.LastExtractedAt = time.Time{}
+	}
+
+	existing, err := s.readSemanticExtractionCheckpoint()
+	if err != nil {
+		return cognition.SemanticExtractionCheckpoint{}, err
+	}
+	if sameSemanticExtractionCheckpoint(existing, state) {
+		return semanticExtractionCheckpointStateToCognition(existing), nil
+	}
+
+	state.UpdatedAt = time.Now().UTC()
+	if err := writeJSONFileAtomic(s.semanticExtractionCheckpointPath(), state); err != nil {
+		return cognition.SemanticExtractionCheckpoint{}, fmt.Errorf(
+			"write semantic extraction checkpoint: %w",
+			err,
+		)
+	}
+	if _, err := s.committer.CommitAll(
+		ctx,
+		s.rootDir,
+		"memory: update semantic extraction checkpoint",
+	); err != nil {
+		return cognition.SemanticExtractionCheckpoint{}, fmt.Errorf(
+			"commit semantic extraction checkpoint: %w",
+			err,
+		)
+	}
+	return semanticExtractionCheckpointStateToCognition(state), nil
 }
 
 // LoadJobState loads persisted cognition trigger state for one job type.
@@ -319,6 +393,19 @@ func sameConsolidationCheckpoint(
 		left.LastConsolidatedAt.UTC().Equal(right.LastConsolidatedAt.UTC())
 }
 
+func sameSemanticExtractionCheckpoint(
+	left semanticExtractionCheckpointState,
+	right semanticExtractionCheckpointState,
+) bool {
+	return left.LastExtractedSeq == right.LastExtractedSeq &&
+		strings.TrimSpace(
+			left.LastExtractedTurnID,
+		) == strings.TrimSpace(
+			right.LastExtractedTurnID,
+		) &&
+		left.LastExtractedAt.UTC().Equal(right.LastExtractedAt.UTC())
+}
+
 func (s *Store) findTurnBySeq(seq int64) (turnRecord, bool, error) {
 	entries, err := s.listTurnEntries()
 	if err != nil {
@@ -356,6 +443,28 @@ func consolidationCheckpointStateToCognition(
 		LastConsolidatedSeq:    max(0, checkpoint.LastConsolidatedSeq),
 		LastConsolidatedAt:     checkpoint.LastConsolidatedAt.UTC(),
 		UpdatedAt:              checkpoint.UpdatedAt.UTC(),
+	}
+}
+
+func semanticExtractionCheckpointStateFromCognition(
+	checkpoint cognition.SemanticExtractionCheckpoint,
+) semanticExtractionCheckpointState {
+	return semanticExtractionCheckpointState{
+		LastExtractedTurnID: strings.TrimSpace(checkpoint.LastExtractedTurnID),
+		LastExtractedSeq:    max(0, checkpoint.LastExtractedSeq),
+		LastExtractedAt:     checkpoint.LastExtractedAt.UTC(),
+		UpdatedAt:           checkpoint.UpdatedAt.UTC(),
+	}
+}
+
+func semanticExtractionCheckpointStateToCognition(
+	checkpoint semanticExtractionCheckpointState,
+) cognition.SemanticExtractionCheckpoint {
+	return cognition.SemanticExtractionCheckpoint{
+		LastExtractedTurnID: strings.TrimSpace(checkpoint.LastExtractedTurnID),
+		LastExtractedSeq:    max(0, checkpoint.LastExtractedSeq),
+		LastExtractedAt:     checkpoint.LastExtractedAt.UTC(),
+		UpdatedAt:           checkpoint.UpdatedAt.UTC(),
 	}
 }
 

--- a/systems/agent/internal/memory/store.go
+++ b/systems/agent/internal/memory/store.go
@@ -24,20 +24,21 @@ import (
 )
 
 const (
-	headStateRelativePath               = "history/state/head.json"
-	consolidationCheckpointRelativePath = "history/state/consolidation_checkpoint.json"
-	readmeRelativePath                  = "README.md"
-	seedDirPath                         = "seeds"
-	coreDirPath                         = "core"
-	semanticDirPath                     = "semantic"
-	workingDirPath                      = "working"
-	workingMemoryFileName               = "WORKING_MEMORY.md"
-	cognitionDirPath                    = "cognition"
-	cognitionStatePath                  = cognitionDirPath + "/state"
-	cognitionIndexerPath                = cognitionDirPath + "/indexer"
-	cognitionRunsPath                   = cognitionDirPath + "/runs"
-	cognitionTriggersPath               = cognitionDirPath + "/triggers"
-	cognitionJobsPath                   = cognitionTriggersPath + "/jobs"
+	headStateRelativePath                    = "history/state/head.json"
+	consolidationCheckpointRelativePath      = "history/state/consolidation_checkpoint.json"
+	semanticExtractionCheckpointRelativePath = "cognition/state/semantic_extraction_checkpoint.json"
+	readmeRelativePath                       = "README.md"
+	seedDirPath                              = "seeds"
+	coreDirPath                              = "core"
+	semanticDirPath                          = "semantic"
+	workingDirPath                           = "working"
+	workingMemoryFileName                    = "WORKING_MEMORY.md"
+	cognitionDirPath                         = "cognition"
+	cognitionStatePath                       = cognitionDirPath + "/state"
+	cognitionIndexerPath                     = cognitionDirPath + "/indexer"
+	cognitionRunsPath                        = cognitionDirPath + "/runs"
+	cognitionTriggersPath                    = cognitionDirPath + "/triggers"
+	cognitionJobsPath                        = cognitionTriggersPath + "/jobs"
 )
 
 const workingMemorySeedPath = seedDirPath + "/" + workingMemoryFileName
@@ -167,6 +168,9 @@ func (s *Store) Init(ctx context.Context) error {
 	if err := s.ensureConsolidationCheckpoint(); err != nil {
 		return err
 	}
+	if err := s.ensureSemanticExtractionCheckpoint(); err != nil {
+		return err
+	}
 
 	upgrade, err := s.upgradeHistory()
 	if err != nil {
@@ -229,6 +233,20 @@ func (s *Store) LoadLatestMessages(ctx context.Context, turns int) ([]conversati
 	defer s.mu.Unlock()
 
 	return s.loadMessagesLocked(turns, false)
+}
+
+// LoadMessagesSinceSeq loads all messages from turns after the provided
+// transcript sequence boundary.
+func (s *Store) LoadMessagesSinceSeq(
+	ctx context.Context,
+	afterSeq int64,
+) ([]conversation.Message, error) {
+	_ = ctx
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.loadMessagesSinceSeqLocked(afterSeq)
 }
 
 // LoadLastUserTimestamp returns the most recent persisted user-message
@@ -401,6 +419,7 @@ This directory contains q15's persistent agent-state root.
 	- Replay checkpoints for consolidated episodic history are stored under history/state/consolidation_checkpoint.json.
 	- Cognition subsystem maintenance state is stored under cognition/.
 	- Job-owned cognition artifacts are stored under cognition/state/.
+	- Semantic extraction replay checkpoints are stored under cognition/state/semantic_extraction_checkpoint.json.
 	- Per-job cognition trigger state is stored under cognition/triggers/jobs/.
 	- Append-only cognition run provenance is stored under cognition/runs/.
 	- Auxiliary notebook files are organized under notes/inbox, notes/zettel, and notes/maps as the built-in zettelkasten layout.
@@ -476,6 +495,23 @@ func (s *Store) ensureConsolidationCheckpoint() error {
 	}
 	if err := writeJSONFileAtomic(path, checkpoint); err != nil {
 		return fmt.Errorf("initialize consolidation checkpoint: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) ensureSemanticExtractionCheckpoint() error {
+	path := s.semanticExtractionCheckpointPath()
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat semantic extraction checkpoint: %w", err)
+	}
+
+	checkpoint := semanticExtractionCheckpointState{
+		UpdatedAt: time.Now().UTC(),
+	}
+	if err := writeJSONFileAtomic(path, checkpoint); err != nil {
+		return fmt.Errorf("initialize semantic extraction checkpoint: %w", err)
 	}
 	return nil
 }
@@ -777,6 +813,28 @@ func (s *Store) readConsolidationCheckpoint() (consolidationCheckpointState, err
 	return checkpoint, nil
 }
 
+func (s *Store) readSemanticExtractionCheckpoint() (semanticExtractionCheckpointState, error) {
+	data, err := os.ReadFile(s.semanticExtractionCheckpointPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return semanticExtractionCheckpointState{}, nil
+		}
+		return semanticExtractionCheckpointState{}, fmt.Errorf(
+			"read semantic extraction checkpoint: %w",
+			err,
+		)
+	}
+
+	var checkpoint semanticExtractionCheckpointState
+	if err := json.Unmarshal(data, &checkpoint); err != nil {
+		return semanticExtractionCheckpointState{}, fmt.Errorf(
+			"decode semantic extraction checkpoint: %w",
+			err,
+		)
+	}
+	return checkpoint, nil
+}
+
 func (s *Store) loadMessagesLocked(
 	turns int,
 	checkpointAware bool,
@@ -831,12 +889,50 @@ func (s *Store) loadMessagesLocked(
 	return out, nil
 }
 
+func (s *Store) loadMessagesSinceSeqLocked(
+	afterSeq int64,
+) ([]conversation.Message, error) {
+	entries, err := s.listTurnEntries()
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	start := sort.Search(len(entries), func(i int) bool {
+		return entries[i].Seq > afterSeq
+	})
+	if start == len(entries) {
+		return nil, nil
+	}
+
+	records := make([]turnRecord, 0, len(entries)-start)
+	for _, entry := range entries[start:] {
+		turn, err := s.readTurn(entry.Path)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, turn)
+	}
+
+	out := make([]conversation.Message, 0, len(records)*2)
+	for _, turn := range records {
+		out = append(out, copyMessages(turn.Messages)...)
+	}
+	return out, nil
+}
+
 func (s *Store) headStatePath() string {
 	return filepath.Join(s.rootDir, headStateRelativePath)
 }
 
 func (s *Store) consolidationCheckpointPath() string {
 	return filepath.Join(s.rootDir, consolidationCheckpointRelativePath)
+}
+
+func (s *Store) semanticExtractionCheckpointPath() string {
+	return filepath.Join(s.rootDir, semanticExtractionCheckpointRelativePath)
 }
 
 func (s *Store) workingMemoryPath() string {

--- a/systems/agent/internal/memory/store_test.go
+++ b/systems/agent/internal/memory/store_test.go
@@ -59,6 +59,7 @@ func TestStoreInitCreatesScaffold(t *testing.T) {
 		filepath.Join(root, "history", "state", "head.json"),
 		filepath.Join(root, "history", "state", "consolidation_checkpoint.json"),
 		filepath.Join(root, "cognition", "state"),
+		filepath.Join(root, "cognition", "state", "semantic_extraction_checkpoint.json"),
 		filepath.Join(root, "cognition", "indexer"),
 		filepath.Join(root, "cognition", "triggers", "jobs"),
 		filepath.Join(root, "cognition", "runs"),
@@ -90,6 +91,7 @@ func TestStoreInitCreatesScaffold(t *testing.T) {
 		"history/state/consolidation_checkpoint.json",
 		"cognition/",
 		"cognition/state/",
+		"cognition/state/semantic_extraction_checkpoint.json",
 		"cognition/triggers/jobs/",
 		"cognition/runs/",
 		"zettelkasten layout",
@@ -382,6 +384,50 @@ func TestStoreLoadLatestMessagesIgnoresConsolidationCheckpoint(t *testing.T) {
 	}
 	if got, want := conversation.TextValue(tail[2]), "three"; got != want {
 		t.Fatalf("LoadLatestMessages third message = %q, want %q", got, want)
+	}
+}
+
+func TestStoreLoadMessagesSinceSeq(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "memory")
+	store := NewStore(root, "Jared", &fakeCommitter{})
+
+	if err := store.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	for _, pair := range [][2]string{
+		{"one", "first"},
+		{"two", "second"},
+		{"three", "third"},
+	} {
+		if err := store.AppendTurn(context.Background(), []conversation.Message{
+			conversation.UserMessage(pair[0]),
+			conversation.AssistantMessage(conversation.Text(pair[1], "")),
+		}); err != nil {
+			t.Fatalf("AppendTurn(%q) error = %v", pair[0], err)
+		}
+	}
+
+	got, err := store.LoadMessagesSinceSeq(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("LoadMessagesSinceSeq() error = %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("LoadMessagesSinceSeq len = %d, want 4", len(got))
+	}
+	if conversation.TextValue(got[0]) != "two" ||
+		conversation.TextValue(got[1]) != "second" ||
+		conversation.TextValue(got[2]) != "three" ||
+		conversation.TextValue(got[3]) != "third" {
+		t.Fatalf("LoadMessagesSinceSeq contents = %#v, want turns after seq 1", got)
+	}
+
+	got, err = store.LoadMessagesSinceSeq(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("LoadMessagesSinceSeq(at head) error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("LoadMessagesSinceSeq(at head) len = %d, want 0", len(got))
 	}
 }
 
@@ -1431,6 +1477,113 @@ func TestStoreStoreConsolidationCheckpoint(t *testing.T) {
 	}
 	if checkpoint.UpdatedAt.IsZero() {
 		t.Fatal("checkpoint.UpdatedAt after no-op = zero, want existing timestamp")
+	}
+}
+
+func TestStoreStoreSemanticExtractionCheckpoint(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "memory")
+	committer := &fakeCommitter{}
+	store := NewStore(root, "Jared", committer)
+	if err := store.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	if err := store.AppendTurn(context.Background(), []conversation.Message{
+		conversation.UserMessage("hello"),
+		conversation.AssistantMessage(conversation.Text("ok", "")),
+	}); err != nil {
+		t.Fatalf("AppendTurn() error = %v", err)
+	}
+
+	turn, ok, err := store.findTurnBySeq(1)
+	if err != nil {
+		t.Fatalf("findTurnBySeq() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("findTurnBySeq() ok = false, want true")
+	}
+
+	checkpoint, err := store.StoreSemanticExtractionCheckpoint(
+		context.Background(),
+		cognition.SemanticExtractionCheckpoint{LastExtractedSeq: 1},
+	)
+	if err != nil {
+		t.Fatalf("StoreSemanticExtractionCheckpoint() error = %v", err)
+	}
+	if committer.lastMessage != "memory: update semantic extraction checkpoint" {
+		t.Fatalf("commit message = %q", committer.lastMessage)
+	}
+	if checkpoint.LastExtractedSeq != 1 {
+		t.Fatalf("checkpoint.LastExtractedSeq = %d, want 1", checkpoint.LastExtractedSeq)
+	}
+	if checkpoint.LastExtractedTurnID != turn.ID {
+		t.Fatalf(
+			"checkpoint.LastExtractedTurnID = %q, want %q",
+			checkpoint.LastExtractedTurnID,
+			turn.ID,
+		)
+	}
+	if !checkpoint.LastExtractedAt.Equal(turn.CreatedAt) {
+		t.Fatalf(
+			"checkpoint.LastExtractedAt = %s, want %s",
+			checkpoint.LastExtractedAt,
+			turn.CreatedAt,
+		)
+	}
+	if checkpoint.UpdatedAt.IsZero() {
+		t.Fatal("checkpoint.UpdatedAt = zero, want non-zero")
+	}
+
+	stored, err := store.readSemanticExtractionCheckpoint()
+	if err != nil {
+		t.Fatalf("readSemanticExtractionCheckpoint() error = %v", err)
+	}
+	if stored.LastExtractedSeq != checkpoint.LastExtractedSeq ||
+		stored.LastExtractedTurnID != checkpoint.LastExtractedTurnID {
+		t.Fatalf("stored checkpoint = %#v, want %#v", stored, checkpoint)
+	}
+	loaded, err := store.LoadSemanticExtractionCheckpoint(context.Background())
+	if err != nil {
+		t.Fatalf("LoadSemanticExtractionCheckpoint() error = %v", err)
+	}
+	if loaded.LastExtractedSeq != checkpoint.LastExtractedSeq ||
+		loaded.LastExtractedTurnID != checkpoint.LastExtractedTurnID ||
+		!loaded.LastExtractedAt.Equal(checkpoint.LastExtractedAt) {
+		t.Fatalf("loaded checkpoint = %#v, want %#v", loaded, checkpoint)
+	}
+
+	commitCalls := committer.commitCalls
+	checkpoint, err = store.StoreSemanticExtractionCheckpoint(
+		context.Background(),
+		cognition.SemanticExtractionCheckpoint{LastExtractedSeq: 1},
+	)
+	if err != nil {
+		t.Fatalf("StoreSemanticExtractionCheckpoint() second error = %v", err)
+	}
+	if committer.commitCalls != commitCalls {
+		t.Fatalf("commit calls = %d, want unchanged %d", committer.commitCalls, commitCalls)
+	}
+	if checkpoint.UpdatedAt.IsZero() {
+		t.Fatal("checkpoint.UpdatedAt after no-op = zero, want existing timestamp")
+	}
+}
+
+func TestStoreLoadSemanticExtractionCheckpointMissingFile(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "memory")
+	store := NewStore(root, "Jared", &fakeCommitter{})
+	if err := store.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if err := os.Remove(store.semanticExtractionCheckpointPath()); err != nil {
+		t.Fatalf("Remove(semantic checkpoint) error = %v", err)
+	}
+
+	checkpoint, err := store.LoadSemanticExtractionCheckpoint(context.Background())
+	if err != nil {
+		t.Fatalf("LoadSemanticExtractionCheckpoint() error = %v", err)
+	}
+	if checkpoint != (cognition.SemanticExtractionCheckpoint{}) {
+		t.Fatalf("checkpoint = %#v, want zero value", checkpoint)
 	}
 }
 

--- a/systems/agent/internal/memory/types.go
+++ b/systems/agent/internal/memory/types.go
@@ -29,6 +29,13 @@ type consolidationCheckpointState struct {
 	UpdatedAt              time.Time `json:"updated_at,omitempty"`
 }
 
+type semanticExtractionCheckpointState struct {
+	LastExtractedTurnID string    `json:"last_extracted_turn_id,omitempty"`
+	LastExtractedSeq    int64     `json:"last_extracted_seq,omitempty"`
+	LastExtractedAt     time.Time `json:"last_extracted_at,omitempty"`
+	UpdatedAt           time.Time `json:"updated_at,omitempty"`
+}
+
 type turnPathEntry struct {
 	Path string
 	Seq  int64


### PR DESCRIPTION
## Summary

Fixes #76 by adding an independent semantic-memory extraction checkpoint at `/memory/cognition/state/semantic_extraction_checkpoint.json`.

- Add semantic extraction checkpoint types and controller/store interfaces.
- Load semantic extraction transcript context from turns after the semantic checkpoint, with the existing latest-32 fallback for first run or migration.
- Advance the semantic checkpoint only after successful `semantic_memory.extract` runs and include checkpoint metadata in run records.
- Keep the working-memory consolidation checkpoint independent and unchanged.

## Validation

- `make project-setup`
- `make fmt FILES='systems/agent/internal/app/runtime_entrypoints_test.go systems/agent/internal/app/runtime_store.go systems/agent/internal/cognition/controller.go systems/agent/internal/cognition/controller_test.go systems/agent/internal/cognition/runner.go systems/agent/internal/cognition/runner_test.go systems/agent/internal/cognition/semantic_memory_job.go systems/agent/internal/cognition/semantic_memory_job_test.go systems/agent/internal/cognition/verification_job_test.go systems/agent/internal/cognition/working_memory_job_test.go systems/agent/internal/memory/cognition_store.go systems/agent/internal/memory/store.go systems/agent/internal/memory/store_test.go systems/agent/internal/memory/types.go'`
- `make lint-changed FILES='systems/agent/internal/app/runtime_entrypoints_test.go systems/agent/internal/app/runtime_store.go systems/agent/internal/cognition/controller.go systems/agent/internal/cognition/controller_test.go systems/agent/internal/cognition/runner.go systems/agent/internal/cognition/runner_test.go systems/agent/internal/cognition/semantic_memory_job.go systems/agent/internal/cognition/semantic_memory_job_test.go systems/agent/internal/cognition/verification_job_test.go systems/agent/internal/cognition/working_memory_job_test.go systems/agent/internal/memory/cognition_store.go systems/agent/internal/memory/store.go systems/agent/internal/memory/store_test.go systems/agent/internal/memory/types.go'`
- `cd systems/agent && CGO_ENABLED=0 go test ./internal/cognition ./internal/memory ./internal/app`
- `make verify`

## Live Stack Check

Verified the running Compose stack with the new agent binary. A semantic extraction run triggered after the threshold, succeeded, and advanced the checkpoint from seq `358` to seq `373` with semantic checkpoint metadata recorded in the run record.