### PR TITLE
[codex] fix telegram polling recovery

### DIFF
--- a/systems/agent/internal/channel/telegram/channel.go
+++ b/systems/agent/internal/channel/telegram/channel.go
@@ -49,6 +49,10 @@ var (
 	telegramTypingKeepaliveInterval = 4 * time.Second
 	telegramTextChunkRunes          = 3800
 	telegramPhotoCaptionRunes       = 1024
+	telegramLongPollTimeoutSeconds  = 30
+	telegramLongPollRequestTimeout  = 45 * time.Second
+	telegramLongPollRetryTimeout    = 8 * time.Second
+	telegramLongPollRestartDelay    = 5 * time.Second
 )
 
 // NewChannel constructs a Telegram channel adapter.
@@ -60,7 +64,10 @@ func NewChannel(token string, onMessage MessageHandler, opts ...Option) (*Channe
 		onMessage = func(IncomingMessage) {}
 	}
 
-	bot, err := telego.NewBot(token)
+	bot, err := telego.NewBot(
+		token,
+		telego.WithHTTPClient(&http.Client{Timeout: telegramLongPollRequestTimeout}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("create telegram bot: %w", err)
 	}
@@ -85,9 +92,54 @@ func NewChannel(token string, onMessage MessageHandler, opts ...Option) (*Channe
 
 // Start begins long polling and dispatches inbound Telegram messages.
 func (c *Channel) Start(ctx context.Context) error {
-	updates, err := c.bot.UpdatesViaLongPolling(ctx, &telego.GetUpdatesParams{
-		Timeout: 30,
-	})
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	go c.superviseLongPolling(ctx)
+	return nil
+}
+
+func (c *Channel) superviseLongPolling(ctx context.Context) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		// Telego owns retries inside one session. This loop only restarts
+		// the session if the update channel or handler stops unexpectedly.
+		err := c.runLongPollingSession(ctx)
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		if err != nil {
+			fmt.Fprintf(
+				os.Stderr,
+				"telegram long polling stopped: %v; restarting in %s\n",
+				err,
+				telegramLongPollRestartDelay,
+			)
+		} else {
+			fmt.Fprintf(
+				os.Stderr,
+				"telegram long polling stopped unexpectedly; restarting in %s\n",
+				telegramLongPollRestartDelay,
+			)
+		}
+		if !sleepContext(ctx, telegramLongPollRestartDelay) {
+			return
+		}
+	}
+}
+
+func (c *Channel) runLongPollingSession(ctx context.Context) error {
+	params := &telego.GetUpdatesParams{
+		Timeout:        telegramLongPollTimeoutSeconds,
+		AllowedUpdates: []string{telego.MessageUpdates},
+	}
+	updates, err := c.bot.UpdatesViaLongPolling(
+		ctx,
+		params,
+		telego.WithLongPollingRetryTimeout(telegramLongPollRetryTimeout),
+	)
 	if err != nil {
 		return fmt.Errorf("start long polling: %w", err)
 	}
@@ -101,15 +153,37 @@ func (c *Channel) Start(ctx context.Context) error {
 		return c.handleMessage(ctx, &message)
 	}, th.AnyMessage())
 
+	stopHandler := make(chan struct{})
 	go func() {
-		_ = bh.Start()
-	}()
-	go func() {
-		<-ctx.Done()
-		_ = bh.Stop()
+		select {
+		case <-ctx.Done():
+			_ = bh.Stop()
+		case <-stopHandler:
+		}
 	}()
 
+	// Start blocks until Telego's update channel closes or the handler stops.
+	if err := bh.Start(); err != nil {
+		close(stopHandler)
+		return fmt.Errorf("run bot handler: %w", err)
+	}
+	close(stopHandler)
 	return nil
+}
+
+func sleepContext(ctx context.Context, delay time.Duration) bool {
+	if delay <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 func (c *Channel) handleMessage(ctx context.Context, message *telego.Message) error {

--- a/systems/agent/internal/channel/telegram/channel_test.go
+++ b/systems/agent/internal/channel/telegram/channel_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -139,6 +140,53 @@ func newTestChannelWithCaller(t *testing.T, caller ta.Caller) *Channel {
 	return &Channel{bot: bot}
 }
 
+type closingThenUpdateCaller struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (c *closingThenUpdateCaller) Call(
+	_ context.Context,
+	_ string,
+	_ *ta.RequestData,
+) (*ta.Response, error) {
+	c.mu.Lock()
+	c.calls++
+	call := c.calls
+	c.mu.Unlock()
+
+	if call == 1 {
+		return nil, context.Canceled
+	}
+	if call == 2 {
+		return &ta.Response{
+			Ok: true,
+			Result: []byte(`[
+				{
+					"update_id": 42,
+					"message": {
+						"message_id": 7,
+						"date": 1710000000,
+						"chat": {"id": 123, "type": "private"},
+						"from": {"id": 456, "is_bot": false, "first_name": "Ada"},
+						"text": "after timeout"
+					}
+				}
+			]`),
+		}, nil
+	}
+	return &ta.Response{
+		Ok:     true,
+		Result: []byte(`[]`),
+	}, nil
+}
+
+func (c *closingThenUpdateCaller) Calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
 func mustStoreMediaRef(
 	t *testing.T,
 	content []byte,
@@ -173,6 +221,50 @@ var testTelegramPNGBytes = []byte{
 	0x03, 0x01, 0x01, 0x00, 0xc9, 0xfe, 0x92, 0xef,
 	0x00, 0x00, 0x00, 0x00, 'I', 'E', 'N', 'D',
 	0xae, 0x42, 0x60, 0x82,
+}
+
+func TestStartRestartsWhenTelegoLongPollingStops(t *testing.T) {
+	prevRestartDelay := telegramLongPollRestartDelay
+	telegramLongPollRestartDelay = time.Millisecond
+	t.Cleanup(func() {
+		telegramLongPollRestartDelay = prevRestartDelay
+	})
+
+	caller := &closingThenUpdateCaller{}
+	ch := newTestChannelWithCaller(t, caller)
+	got := make(chan IncomingMessage, 1)
+	ch.onMessage = func(msg IncomingMessage) {
+		got <- msg
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := ch.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	select {
+	case msg := <-got:
+		cancel()
+		if msg.ChatID != "123" {
+			t.Fatalf("ChatID = %q, want 123", msg.ChatID)
+		}
+		if msg.UserID != "456" {
+			t.Fatalf("UserID = %q, want 456", msg.UserID)
+		}
+		if msg.MessageID != "7" {
+			t.Fatalf("MessageID = %q, want 7", msg.MessageID)
+		}
+		if msg.Text != "after timeout" {
+			t.Fatalf("Text = %q, want after timeout", msg.Text)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for recovered Telegram update")
+	}
+
+	if gotCalls := caller.Calls(); gotCalls < 2 {
+		t.Fatalf("calls = %d, want at least 2", gotCalls)
+	}
 }
 
 func TestSendText_UsesHTMLParseMode(t *testing.T) {


### PR DESCRIPTION
## Summary
- Keep Telego's built-in long polling and handler dispatch in charge of Telegram updates.
- Add bounded Telegram API calls plus a q15 supervisor that restarts the polling session if Telego's update channel or handler stops while q15 is still running.
- Add a regression test covering recovery after the long-polling session stops.

## Validation
- `make fmt FILES='systems/agent/internal/channel/telegram/channel.go systems/agent/internal/channel/telegram/channel_test.go'`
- `make lint-changed FILES='systems/agent/internal/channel/telegram/channel.go systems/agent/internal/channel/telegram/channel_test.go'`
- `GOCACHE=/tmp/q15-go-cache go test ./internal/channel/telegram`
- `XDG_CACHE_HOME=/tmp/q15-xdg-cache GOCACHE=/tmp/q15-go-cache make verify`