### PR TITLE
[codex] configure brave web search from agent config

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ q15 uses a narrow container-first runtime contract:
 - agent config is a mounted YAML file at `/etc/q15/agent/config.yaml`
 - proxy policy is a mounted YAML file at `/etc/q15/proxy/policy.yaml`
 - auth credentials are a mounted JSON file at `/etc/q15/auth/auth.json`
-- provider, Telegram, and proxy secrets come from env vars or `_FILE`
+- provider, Brave, Telegram, and proxy secrets come from env vars or `_FILE`
 - service topology, ports, and runtime directories are hard-coded
 
 The fixed runtime contract is:
@@ -206,7 +206,7 @@ locations) in long-running deployments.
 
 ### Agent Config
 
-Keep the agent file focused on identity, models, providers, and Telegram policy.
+Keep the agent file focused on identity, models, providers, optional tools, and Telegram policy.
 
 Example:
 
@@ -245,6 +245,9 @@ agent:
       - kimi-k2.5
       - gpt-5.4
   memory_recent_turns: 6
+  tools:
+    web_search:
+      brave_api_key_env: BRAVE_API_KEY
   telegram:
     token_env: Q15_TELEGRAM_TOKEN
     allowed_user_ids_env: Q15_TELEGRAM_ALLOWED_USER_IDS
@@ -252,10 +255,12 @@ agent:
 
 Notes:
 
-- provider keys, Telegram tokens, and Telegram allowed-user lists can come from `NAME` or
-  `NAME_FILE`
+- provider keys, Brave API keys, Telegram tokens, and Telegram allowed-user lists can come from
+  `NAME` or `NAME_FILE`
 - `openai-codex` uses `/etc/q15/auth/auth.json` from `q15-auth`; `openai-compatible` providers use
   `key_env`
+- `agent.tools.web_search.brave_api_key_env` is optional; omit it to disable `web_search`; when it
+  is set, q15 resolves that env var through `NAME` or `NAME_FILE`
 - `models[].capabilities` drive capability-aware selection; q15 skips models that cannot satisfy the
   currently inferred request requirements before calling a provider
 - `agent.models` order is the deterministic per-turn fallback preference order after capability
@@ -265,7 +270,8 @@ Notes:
 - current inference is intentionally text-first; image-input and tool-calling requirement inference
   land when canonical request signals for those modes are available
 - agent memory lives under `/memory`
-- `Q15_BRAVE_API_KEY` remains optional for Brave web search
+- `BRAVE_API_KEY` / `BRAVE_API_KEY_FILE` is the default Brave web-search secret name used by the
+  checked-in deployment examples
 
 ### Conversation History
 

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -35,6 +35,9 @@ Notes:
   checked-in Compose example uses OpenAI `gpt-5.4` first and Moonshot/Kimi second.
 - `agent.cognition.models` is optional and defines the background-cognition fallback order. If it is
   omitted, cognition jobs inherit `agent.models`.
+- The checked-in Compose agent config enables Brave Search with
+  `agent.tools.web_search.brave_api_key_env: BRAVE_API_KEY`, and the Compose file mounts that
+  optional secret as `BRAVE_API_KEY_FILE=/run/q15-secrets/brave_api_key`.
 - The checked-in Compose config reads the Telegram allow-list from `Q15_TELEGRAM_ALLOWED_USER_IDS`
   or `Q15_TELEGRAM_ALLOWED_USER_IDS_FILE`, so local user IDs stay out of tracked YAML.
 - Update or rollback by changing the pinned tag and redeploying while preserving the persistent

--- a/deploy/compose/agent-config.yaml
+++ b/deploy/compose/agent-config.yaml
@@ -36,6 +36,9 @@ agent:
       - kimi-k2.6
       - gpt-5.5
   memory_recent_turns: 6
+  tools:
+    web_search:
+      brave_api_key_env: BRAVE_API_KEY
   telegram:
     token_env: Q15_TELEGRAM_TOKEN
     allowed_user_ids_env: Q15_TELEGRAM_ALLOWED_USER_IDS

--- a/deploy/compose/docker-compose.image-first.yml
+++ b/deploy/compose/docker-compose.image-first.yml
@@ -60,7 +60,7 @@ services:
       ZAI_API_KEY_FILE: /run/q15-secrets/zai_api_key
       Q15_TELEGRAM_TOKEN_FILE: /run/q15-secrets/q15_telegram_token
       Q15_TELEGRAM_ALLOWED_USER_IDS_FILE: /run/q15-secrets/q15_telegram_allowed_user_ids
-      Q15_BRAVE_API_KEY: ${Q15_BRAVE_API_KEY-}
+      BRAVE_API_KEY_FILE: /run/q15-secrets/brave_api_key
     volumes:
       - type: bind
         source: ./agent-config.yaml
@@ -77,6 +77,10 @@ services:
       - type: bind
         source: ./secrets/zai_api_key
         target: /run/q15-secrets/zai_api_key
+        read_only: true
+      - type: bind
+        source: ./secrets/brave_api_key
+        target: /run/q15-secrets/brave_api_key
         read_only: true
       - type: bind
         source: ./secrets/q15_telegram_token

--- a/deploy/compose/secrets/README.md
+++ b/deploy/compose/secrets/README.md
@@ -12,6 +12,7 @@ Rules:
 - The generic tracked templates are:
   - `moonshot_api_key.example`
   - `zai_api_key.example`
+  - `brave_api_key.example`
   - `q15_telegram_token.example`
   - `q15_telegram_allowed_user_ids.example`
   - `github_token.example`

--- a/deploy/compose/secrets/brave_api_key.example
+++ b/deploy/compose/secrets/brave_api_key.example
@@ -1,0 +1,1 @@
+replace-me

--- a/deploy/kubernetes/base/README.md
+++ b/deploy/kubernetes/base/README.md
@@ -25,7 +25,8 @@ The runtime contract is fixed in the binaries. Overlays only need to provide:
 - `ConfigMap/q15-agent-config` data matching `agent-config.yaml`
 - `ConfigMap/q15-proxy-policy` data matching `proxy-policy.yaml`
 - `Secret/q15-agent-env` with keys referenced by the agent config
-  - Example: `MOONSHOT_API_KEY`, `Q15_TELEGRAM_TOKEN`, `Q15_TELEGRAM_ALLOWED_USER_IDS`
+  - Example: `MOONSHOT_API_KEY`, `BRAVE_API_KEY`, `Q15_TELEGRAM_TOKEN`,
+    `Q15_TELEGRAM_ALLOWED_USER_IDS`
 - `Secret/q15-agent-auth` with key `auth.json`
 - `Secret/q15-proxy-env` with keys matching the uppercased proxy secret aliases in
   `proxy-policy.yaml`

--- a/deploy/kubernetes/base/agent-config.yaml
+++ b/deploy/kubernetes/base/agent-config.yaml
@@ -20,6 +20,9 @@ agent:
     models:
       - kimi-k2.5
   memory_recent_turns: 6
+  tools:
+    web_search:
+      brave_api_key_env: BRAVE_API_KEY
   telegram:
     token_env: Q15_TELEGRAM_TOKEN
     allowed_user_ids_env: Q15_TELEGRAM_ALLOWED_USER_IDS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       ZAI_API_KEY_FILE: /run/secrets/zai_api_key
       Q15_TELEGRAM_TOKEN_FILE: /run/secrets/q15_telegram_token
       Q15_TELEGRAM_ALLOWED_USER_IDS_FILE: /run/secrets/q15_telegram_allowed_user_ids
-      Q15_BRAVE_API_KEY: ${Q15_BRAVE_API_KEY-}
+      BRAVE_API_KEY_FILE: /run/secrets/brave_api_key
     configs:
       - source: q15_agent_config
         target: /etc/q15/agent/config.yaml
@@ -90,6 +90,7 @@ services:
     secrets:
       - moonshot_api_key
       - zai_api_key
+      - brave_api_key
       - q15_telegram_token
       - q15_telegram_allowed_user_ids
 
@@ -113,6 +114,8 @@ secrets:
     file: ./deploy/compose/secrets/moonshot_api_key
   zai_api_key:
     file: ./deploy/compose/secrets/zai_api_key
+  brave_api_key:
+    file: ./deploy/compose/secrets/brave_api_key
   q15_telegram_token:
     file: ./deploy/compose/secrets/q15_telegram_token
   q15_telegram_allowed_user_ids:

--- a/systems/agent/internal/app/bot.go
+++ b/systems/agent/internal/app/bot.go
@@ -88,14 +88,13 @@ func runBot(ctx context.Context, rt config.AgentRuntime) error {
 		SkillsRuntimeDir:    runtimeInfo.SkillsDir,
 	}
 	fileExec := q15skills.NewFileExecutor(fileops.NewExecutor(fileSettings), skillManager)
-	braveAPIKey := strings.TrimSpace(os.Getenv("Q15_BRAVE_API_KEY"))
 	toolList, err := buildToolList(
 		executionClient,
 		fileExec,
 		skillManager,
 		fileSettings,
 		mediaStore,
-		braveAPIKey,
+		rt.Tools.WebSearch.BraveAPIKey,
 	)
 	if err != nil {
 		return fmt.Errorf("configure tools for agent %q: %w", rt.Name, err)

--- a/systems/agent/internal/config/config.go
+++ b/systems/agent/internal/config/config.go
@@ -50,12 +50,23 @@ type Agent struct {
 	Models            []string  `yaml:"models"`
 	Cognition         Cognition `yaml:"cognition"`
 	MemoryRecentTurns int       `yaml:"memory_recent_turns"`
+	Tools             Tools     `yaml:"tools"`
 	Telegram          Telegram  `yaml:"telegram"`
 }
 
 // Cognition defines optional background cognition settings for an agent.
 type Cognition struct {
 	Models []string `yaml:"models"`
+}
+
+// Tools defines optional agent tool settings.
+type Tools struct {
+	WebSearch WebSearchTool `yaml:"web_search"`
+}
+
+// WebSearchTool defines optional web_search settings.
+type WebSearchTool struct {
+	BraveAPIKeyEnv string `yaml:"brave_api_key_env"`
 }
 
 // Telegram defines Telegram integration settings for an agent.
@@ -90,6 +101,16 @@ type ExecutionRuntime struct {
 	ServiceAddress string
 }
 
+// ToolsRuntime is the resolved runtime tool configuration for an agent.
+type ToolsRuntime struct {
+	WebSearch WebSearchToolRuntime
+}
+
+// WebSearchToolRuntime is the resolved runtime configuration for web_search.
+type WebSearchToolRuntime struct {
+	BraveAPIKey string
+}
+
 // AgentRuntime is the resolved runtime config for the configured agent.
 type AgentRuntime struct {
 	Name                   string
@@ -101,6 +122,7 @@ type AgentRuntime struct {
 	SkillsLocalDir         string
 	MemoryRecentTurns      int
 	Execution              ExecutionRuntime
+	Tools                  ToolsRuntime
 	TelegramToken          string
 	TelegramAllowedUserIDs []int64
 }
@@ -228,6 +250,23 @@ func (a Agent) TelegramAllowedUserIDs() ([]int64, error) {
 	return parseAllowedUserIDs(value)
 }
 
+// BraveAPIKey resolves the optional Brave Search API key for web_search.
+func (a Agent) BraveAPIKey() (string, error) {
+	envName := strings.TrimSpace(a.Tools.WebSearch.BraveAPIKeyEnv)
+	if envName == "" {
+		return "", nil
+	}
+
+	value, ok, err := lookupSecretEnvValue(envName)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("env var %q or %q is required", envName, envName+"_FILE")
+	}
+	return value, nil
+}
+
 // ResolveAgentRuntime resolves the configured agent into a runtime value.
 func (c Config) ResolveAgentRuntime() (*AgentRuntime, error) {
 	if err := c.Validate(); err != nil {
@@ -276,6 +315,10 @@ func (c Config) ResolveAgentRuntime() (*AgentRuntime, error) {
 			err,
 		)
 	}
+	braveAPIKey, err := agentCfg.BraveAPIKey()
+	if err != nil {
+		return nil, fmt.Errorf("resolve brave API key for agent %q: %w", agentCfg.Name, err)
+	}
 
 	memoryRecentTurns := agentCfg.MemoryRecentTurns
 	if memoryRecentTurns == 0 {
@@ -283,15 +326,20 @@ func (c Config) ResolveAgentRuntime() (*AgentRuntime, error) {
 	}
 
 	return &AgentRuntime{
-		Name:                   strings.TrimSpace(agentCfg.Name),
-		InteractiveModels:      interactiveModels,
-		CognitionModels:        cognitionModels,
-		WorkspaceLocalDir:      runtimeWorkspaceLocalDir,
-		MemoryLocalDir:         "/memory",
-		MediaLocalDir:          runtimeMediaLocalDir,
-		SkillsLocalDir:         runtimeSkillsLocalDir,
-		MemoryRecentTurns:      memoryRecentTurns,
-		Execution:              ExecutionRuntime{ServiceAddress: runtimeExecutionServiceAddr},
+		Name:              strings.TrimSpace(agentCfg.Name),
+		InteractiveModels: interactiveModels,
+		CognitionModels:   cognitionModels,
+		WorkspaceLocalDir: runtimeWorkspaceLocalDir,
+		MemoryLocalDir:    "/memory",
+		MediaLocalDir:     runtimeMediaLocalDir,
+		SkillsLocalDir:    runtimeSkillsLocalDir,
+		MemoryRecentTurns: memoryRecentTurns,
+		Execution:         ExecutionRuntime{ServiceAddress: runtimeExecutionServiceAddr},
+		Tools: ToolsRuntime{
+			WebSearch: WebSearchToolRuntime{
+				BraveAPIKey: braveAPIKey,
+			},
+		},
 		TelegramToken:          token,
 		TelegramAllowedUserIDs: allowedUserIDs,
 	}, nil

--- a/systems/agent/internal/config/config_test.go
+++ b/systems/agent/internal/config/config_test.go
@@ -182,6 +182,96 @@ agent:
 	}
 }
 
+func TestLoadAgentRuntimeYAMLResolvesBraveAPIKeyFromConfiguredEnvFile(t *testing.T) {
+	t.Setenv("MOONSHOT_API_KEY", "api-123")
+	t.Setenv("Q15_TELEGRAM_TOKEN", "tg-123")
+	bravePath := filepath.Join(t.TempDir(), "brave_api_key")
+	if err := os.WriteFile(bravePath, []byte("brave-123\n"), 0o600); err != nil {
+		t.Fatalf("write brave api key: %v", err)
+	}
+	t.Setenv("BRAVE_API_KEY_FILE", bravePath)
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+providers:
+  - name: moonshot
+    type: openai-compatible
+    base_url: https://api.moonshot.ai/v1
+    key_env: MOONSHOT_API_KEY
+
+models:
+  - name: kimi-k2.5
+    provider: moonshot
+
+agent:
+  name: Q15
+  models:
+    - kimi-k2.5
+  tools:
+    web_search:
+      brave_api_key_env: BRAVE_API_KEY
+  telegram:
+    token_env: Q15_TELEGRAM_TOKEN
+    allowed_user_ids:
+      - 123456789
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	runtime, err := LoadAgentRuntime(path)
+	if err != nil {
+		t.Fatalf("LoadAgentRuntime() error = %v", err)
+	}
+	if runtime.Tools.WebSearch.BraveAPIKey != "brave-123" {
+		t.Fatalf(
+			"Tools.WebSearch.BraveAPIKey = %q, want %q",
+			runtime.Tools.WebSearch.BraveAPIKey,
+			"brave-123",
+		)
+	}
+}
+
+func TestLoadAgentRuntimeYAMLRequiresConfiguredBraveAPIKeyEnv(t *testing.T) {
+	t.Setenv("MOONSHOT_API_KEY", "api-123")
+	t.Setenv("Q15_TELEGRAM_TOKEN", "tg-123")
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+providers:
+  - name: moonshot
+    type: openai-compatible
+    base_url: https://api.moonshot.ai/v1
+    key_env: MOONSHOT_API_KEY
+
+models:
+  - name: kimi-k2.5
+    provider: moonshot
+
+agent:
+  name: Q15
+  models:
+    - kimi-k2.5
+  tools:
+    web_search:
+      brave_api_key_env: BRAVE_API_KEY
+  telegram:
+    token_env: Q15_TELEGRAM_TOKEN
+    allowed_user_ids:
+      - 123456789
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := LoadAgentRuntime(path)
+	if err == nil ||
+		!strings.Contains(
+			err.Error(),
+			`env var "BRAVE_API_KEY" or "BRAVE_API_KEY_FILE" is required`,
+		) {
+		t.Fatalf("LoadAgentRuntime() error = %v, want missing BRAVE_API_KEY", err)
+	}
+}
+
 func TestLoadAgentRuntimeYAMLResolvesSeparateCognitionModels(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "api-openai")
 	t.Setenv("MOONSHOT_API_KEY", "api-moonshot")

--- a/systems/agent/internal/config/secret_env.go
+++ b/systems/agent/internal/config/secret_env.go
@@ -7,29 +7,43 @@ import (
 	"strings"
 )
 
-func resolveSecretEnvValue(name string) (string, error) {
+// lookupSecretEnvValue resolves a secret from NAME or NAME_FILE and reports
+// whether either source was configured.
+func lookupSecretEnvValue(name string) (string, bool, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return "", fmt.Errorf("env var name is required")
+		return "", false, fmt.Errorf("env var name is required")
 	}
 
 	if value := strings.TrimSpace(os.Getenv(name)); value != "" {
-		return value, nil
+		return value, true, nil
 	}
 
 	fileEnvName := name + "_FILE"
 	filePath := strings.TrimSpace(os.Getenv(fileEnvName))
 	if filePath == "" {
-		return "", fmt.Errorf("env var %q or %q is required", name, fileEnvName)
+		return "", false, nil
 	}
 
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		return "", fmt.Errorf("read %q from %q: %w", fileEnvName, filePath, err)
+		return "", true, fmt.Errorf("read %q from %q: %w", fileEnvName, filePath, err)
 	}
 	value := strings.TrimSpace(string(data))
 	if value == "" {
-		return "", fmt.Errorf("%q points to an empty file %q", fileEnvName, filePath)
+		return "", true, fmt.Errorf("%q points to an empty file %q", fileEnvName, filePath)
+	}
+	return value, true, nil
+}
+
+func resolveSecretEnvValue(name string) (string, error) {
+	value, ok, err := lookupSecretEnvValue(name)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		name = strings.TrimSpace(name)
+		return "", fmt.Errorf("env var %q or %q is required", name, name+"_FILE")
 	}
 	return value, nil
 }

--- a/systems/agent/internal/config/secret_env_test.go
+++ b/systems/agent/internal/config/secret_env_test.go
@@ -58,3 +58,65 @@ func TestResolveSecretEnvValue(t *testing.T) {
 		})
 	}
 }
+
+func TestLookupSecretEnvValue(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(filePath, []byte("file-secret\n"), 0o600); err != nil {
+		t.Fatalf("write secret file: %v", err)
+	}
+	emptyPath := filepath.Join(t.TempDir(), "empty.txt")
+	if err := os.WriteFile(emptyPath, nil, 0o600); err != nil {
+		t.Fatalf("write empty file: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		envValue string
+		filePath string
+		want     string
+		wantOK   bool
+		wantErr  string
+	}{
+		{
+			name:     "direct env wins",
+			envValue: "env-secret",
+			filePath: filePath,
+			want:     "env-secret",
+			wantOK:   true,
+		},
+		{name: "file fallback", filePath: filePath, want: "file-secret", wantOK: true},
+		{name: "missing env and file"},
+		{name: "empty file", filePath: emptyPath, wantOK: true, wantErr: "points to an empty file"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("OPTIONAL_SECRET", tc.envValue)
+			t.Setenv("OPTIONAL_SECRET_FILE", tc.filePath)
+
+			got, ok, err := lookupSecretEnvValue("OPTIONAL_SECRET")
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf(
+						"LookupSecretEnvValue() error = %v, want substring %q",
+						err,
+						tc.wantErr,
+					)
+				}
+				if ok != tc.wantOK {
+					t.Fatalf("LookupSecretEnvValue() ok = %v, want %v", ok, tc.wantOK)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LookupSecretEnvValue() error = %v", err)
+			}
+			if ok != tc.wantOK {
+				t.Fatalf("LookupSecretEnvValue() ok = %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Fatalf("LookupSecretEnvValue() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/systems/agent/internal/tools/web/web.go
+++ b/systems/agent/internal/tools/web/web.go
@@ -10,15 +10,18 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/q15co/q15/systems/agent/internal/agent"
 )
 
 const (
-	braveSearchURL        = "https://api.search.brave.com/res/v1/web/search"
-	defaultWebSearchCount = 5
-	maxWebSearchCount     = 10
-	maxErrorResponseBody  = 200
+	braveSearchURL           = "https://api.search.brave.com/res/v1/web/search"
+	defaultWebSearchCount    = 5
+	maxWebSearchCount        = 10
+	maxBraveSearchQueryChars = 400
+	maxBraveSearchQueryWords = 50
+	maxErrorResponseBody     = 200
 )
 
 // BraveWebSearch queries the Brave Search API and formats a text result list.
@@ -51,6 +54,7 @@ func (b *BraveWebSearch) Definition() agent.ToolDefinition {
 		Description: "Search the web for current information using Brave Search and return titles, URLs, and snippets.",
 		PromptGuidance: []string{
 			"Use for discovery when the question depends on current web information.",
+			"Keep queries concise: Brave rejects queries over 400 characters or 50 words; use search keywords, not full paragraphs.",
 			"After choosing a result, use web_fetch on the selected URL when you need the page contents.",
 		},
 		Parameters: map[string]any{
@@ -58,7 +62,8 @@ func (b *BraveWebSearch) Definition() agent.ToolDefinition {
 			"properties": map[string]any{
 				"query": map[string]any{
 					"type":        "string",
-					"description": "Search query",
+					"description": "Concise search query (max 400 characters and 50 words)",
+					"maxLength":   maxBraveSearchQueryChars,
 				},
 				"count": map[string]any{
 					"type":        "integer",
@@ -89,9 +94,12 @@ func (b *BraveWebSearch) Run(ctx context.Context, arguments string) (string, err
 		return "", fmt.Errorf("invalid arguments JSON: %w", err)
 	}
 
-	query := strings.TrimSpace(args.Query)
+	query := normalizeSearchQuery(args.Query)
 	if query == "" {
 		return "", fmt.Errorf("missing required argument: query")
+	}
+	if err := validateSearchQuery(query); err != nil {
+		return "", err
 	}
 
 	count := b.maxResults
@@ -181,6 +189,28 @@ func trimForError(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "..."
+}
+
+func normalizeSearchQuery(query string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(query)), " ")
+}
+
+func validateSearchQuery(query string) error {
+	if charCount := utf8.RuneCountInString(query); charCount > maxBraveSearchQueryChars {
+		return fmt.Errorf(
+			"query is too long for Brave Search: %d characters, maximum is %d; retry with a shorter search query",
+			charCount,
+			maxBraveSearchQueryChars,
+		)
+	}
+	if wordCount := len(strings.Fields(query)); wordCount > maxBraveSearchQueryWords {
+		return fmt.Errorf(
+			"query is too long for Brave Search: %d words, maximum is %d; retry with a concise keyword search",
+			wordCount,
+			maxBraveSearchQueryWords,
+		)
+	}
+	return nil
 }
 
 func clamp(v, minV, maxV int) int {

--- a/systems/agent/internal/tools/web/web_test.go
+++ b/systems/agent/internal/tools/web/web_test.go
@@ -18,6 +18,23 @@ func TestBraveWebSearchDefinition(t *testing.T) {
 	if def.Name != "web_search" {
 		t.Fatalf("Definition().Name = %q, want %q", def.Name, "web_search")
 	}
+	properties, ok := def.Parameters["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf(
+			"Definition().Parameters[properties] = %#v, want object",
+			def.Parameters["properties"],
+		)
+	}
+	query, ok := properties["query"].(map[string]any)
+	if !ok {
+		t.Fatalf(
+			"Definition().Parameters.properties[query] = %#v, want object",
+			properties["query"],
+		)
+	}
+	if got := query["maxLength"]; got != maxBraveSearchQueryChars {
+		t.Fatalf("query maxLength = %#v, want %d", got, maxBraveSearchQueryChars)
+	}
 }
 
 func TestBraveWebSearchRunErrorsOnInvalidJSON(t *testing.T) {
@@ -35,6 +52,44 @@ func TestBraveWebSearchRunErrorsOnMissingQuery(t *testing.T) {
 	_, err := tool.Run(context.Background(), `{"query":"   "}`)
 	if err == nil || !strings.Contains(err.Error(), "missing required argument: query") {
 		t.Fatalf("Run() error = %v, want missing query error", err)
+	}
+}
+
+func TestBraveWebSearchRunErrorsBeforeRequestOnTooLongQuery(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+
+	tool, _ := NewBraveWebSearch("test-key")
+	tool.baseURL = server.URL
+	tool.client = server.Client()
+
+	cases := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "characters",
+			query: strings.Repeat("a", maxBraveSearchQueryChars+1),
+			want:  "401 characters",
+		},
+		{
+			name:  "words",
+			query: strings.TrimSpace(strings.Repeat("word ", maxBraveSearchQueryWords+1)),
+			want:  "51 words",
+		},
+	}
+	for _, tc := range cases {
+		_, err := tool.Run(context.Background(), `{"query":"`+tc.query+`"}`)
+		if err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Fatalf("%s Run() error = %v, want %q", tc.name, err, tc.want)
+		}
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
 	}
 }
 
@@ -68,7 +123,7 @@ func TestBraveWebSearchRunFormatsResults(t *testing.T) {
 	tool.baseURL = server.URL
 	tool.client = server.Client()
 
-	got, err := tool.Run(context.Background(), `{"query":"golang news","count":2}`)
+	got, err := tool.Run(context.Background(), `{"query":"  golang\n news  ","count":2}`)
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}


### PR DESCRIPTION
## What changed

- Added `agent.tools.web_search.brave_api_key_env` so Brave web search is enabled explicitly from agent YAML config.
- Resolved the configured Brave secret through the existing `NAME` / `NAME_FILE` secret pattern and passed it through resolved runtime tool settings.
- Updated Compose and Kubernetes examples to use `BRAVE_API_KEY_FILE` backed by a `brave_api_key` secret template.
- Added local Brave query normalization and validation for Brave's documented query limits before sending requests.

## Why

Brave web search was previously configured by a hardcoded `Q15_BRAVE_API_KEY` env read in `bot.go`, unlike provider keys and Telegram secrets. Moving the setting into YAML keeps tool availability visible in config, makes the secret source explicit, and avoids a one-off runtime path.

## Impact

Deployments that want `web_search` should configure:

```yaml
agent:
  tools:
    web_search:
      brave_api_key_env: BRAVE_API_KEY
```

and provide either `BRAVE_API_KEY` or `BRAVE_API_KEY_FILE`. Omitting the block leaves `web_search` disabled.

## Validation

- `make fmt FILES='README.md deploy/compose/README.md deploy/compose/agent-config.yaml deploy/compose/docker-compose.image-first.yml deploy/compose/secrets/README.md deploy/compose/secrets/brave_api_key.example deploy/kubernetes/base/README.md deploy/kubernetes/base/agent-config.yaml docker-compose.yml systems/agent/internal/app/bot.go systems/agent/internal/config/config.go systems/agent/internal/config/config_test.go systems/agent/internal/config/secret_env.go systems/agent/internal/config/secret_env_test.go systems/agent/internal/tools/web/web.go systems/agent/internal/tools/web/web_test.go'`
- `make lint-changed FILES='README.md deploy/compose/README.md deploy/compose/agent-config.yaml deploy/compose/docker-compose.image-first.yml deploy/compose/secrets/README.md deploy/compose/secrets/brave_api_key.example deploy/kubernetes/base/README.md deploy/kubernetes/base/agent-config.yaml docker-compose.yml systems/agent/internal/app/bot.go systems/agent/internal/config/config.go systems/agent/internal/config/config_test.go systems/agent/internal/config/secret_env.go systems/agent/internal/config/secret_env_test.go systems/agent/internal/tools/web/web.go systems/agent/internal/tools/web/web_test.go'`
- `XDG_CACHE_HOME=/tmp/q15-xdg-cache GOCACHE=/tmp/q15-go-cache make verify`