### PR TITLE
[codex] Add exec session listing

### DIFF
--- a/libs/exec-contract/execpb/contract_test.go
+++ b/libs/exec-contract/execpb/contract_test.go
@@ -7,5 +7,7 @@ func TestGeneratedContractTypesCompile(t *testing.T) {
 
 	_ = &StartSessionRequest{}
 	_ = &StartSessionResponse{}
+	_ = &ListSessionsRequest{}
+	_ = &ListSessionsResponse{}
 	_ = &WatchSessionResponse{}
 }

--- a/libs/exec-contract/execpb/execution.pb.go
+++ b/libs/exec-contract/execpb/execution.pb.go
@@ -611,6 +611,86 @@ func (x *GetSessionResponse) GetSession() *Session {
 	return nil
 }
 
+type ListSessionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSessionsRequest) Reset() {
+	*x = ListSessionsRequest{}
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSessionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSessionsRequest) ProtoMessage() {}
+
+func (x *ListSessionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSessionsRequest.ProtoReflect.Descriptor instead.
+func (*ListSessionsRequest) Descriptor() ([]byte, []int) {
+	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{8}
+}
+
+type ListSessionsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Sessions      []*Session             `protobuf:"bytes,1,rep,name=sessions,proto3" json:"sessions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSessionsResponse) Reset() {
+	*x = ListSessionsResponse{}
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSessionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSessionsResponse) ProtoMessage() {}
+
+func (x *ListSessionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSessionsResponse.ProtoReflect.Descriptor instead.
+func (*ListSessionsResponse) Descriptor() ([]byte, []int) {
+	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *ListSessionsResponse) GetSessions() []*Session {
+	if x != nil {
+		return x.Sessions
+	}
+	return nil
+}
+
 type WatchSessionRequest struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	SessionId       string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
@@ -621,7 +701,7 @@ type WatchSessionRequest struct {
 
 func (x *WatchSessionRequest) Reset() {
 	*x = WatchSessionRequest{}
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[8]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -633,7 +713,7 @@ func (x *WatchSessionRequest) String() string {
 func (*WatchSessionRequest) ProtoMessage() {}
 
 func (x *WatchSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[8]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -646,7 +726,7 @@ func (x *WatchSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchSessionRequest.ProtoReflect.Descriptor instead.
 func (*WatchSessionRequest) Descriptor() ([]byte, []int) {
-	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{8}
+	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *WatchSessionRequest) GetSessionId() string {
@@ -672,7 +752,7 @@ type WatchSessionResponse struct {
 
 func (x *WatchSessionResponse) Reset() {
 	*x = WatchSessionResponse{}
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[9]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -684,7 +764,7 @@ func (x *WatchSessionResponse) String() string {
 func (*WatchSessionResponse) ProtoMessage() {}
 
 func (x *WatchSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[9]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -697,7 +777,7 @@ func (x *WatchSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchSessionResponse.ProtoReflect.Descriptor instead.
 func (*WatchSessionResponse) Descriptor() ([]byte, []int) {
-	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{9}
+	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *WatchSessionResponse) GetEvent() *SessionEvent {
@@ -718,7 +798,7 @@ type WriteSessionStdinRequest struct {
 
 func (x *WriteSessionStdinRequest) Reset() {
 	*x = WriteSessionStdinRequest{}
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[10]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -730,7 +810,7 @@ func (x *WriteSessionStdinRequest) String() string {
 func (*WriteSessionStdinRequest) ProtoMessage() {}
 
 func (x *WriteSessionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[10]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -743,7 +823,7 @@ func (x *WriteSessionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteSessionStdinRequest.ProtoReflect.Descriptor instead.
 func (*WriteSessionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{10}
+	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *WriteSessionStdinRequest) GetSessionId() string {
@@ -777,7 +857,7 @@ type WriteSessionStdinResponse struct {
 
 func (x *WriteSessionStdinResponse) Reset() {
 	*x = WriteSessionStdinResponse{}
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[11]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -789,7 +869,7 @@ func (x *WriteSessionStdinResponse) String() string {
 func (*WriteSessionStdinResponse) ProtoMessage() {}
 
 func (x *WriteSessionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[11]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -802,7 +882,7 @@ func (x *WriteSessionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteSessionStdinResponse.ProtoReflect.Descriptor instead.
 func (*WriteSessionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{11}
+	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *WriteSessionStdinResponse) GetSession() *Session {
@@ -829,7 +909,7 @@ type TerminateSessionRequest struct {
 
 func (x *TerminateSessionRequest) Reset() {
 	*x = TerminateSessionRequest{}
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[12]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -841,7 +921,7 @@ func (x *TerminateSessionRequest) String() string {
 func (*TerminateSessionRequest) ProtoMessage() {}
 
 func (x *TerminateSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[12]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -854,7 +934,7 @@ func (x *TerminateSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSessionRequest.ProtoReflect.Descriptor instead.
 func (*TerminateSessionRequest) Descriptor() ([]byte, []int) {
-	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{12}
+	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *TerminateSessionRequest) GetSessionId() string {
@@ -880,7 +960,7 @@ type TerminateSessionResponse struct {
 
 func (x *TerminateSessionResponse) Reset() {
 	*x = TerminateSessionResponse{}
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[13]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -892,7 +972,7 @@ func (x *TerminateSessionResponse) String() string {
 func (*TerminateSessionResponse) ProtoMessage() {}
 
 func (x *TerminateSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[13]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -905,7 +985,7 @@ func (x *TerminateSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSessionResponse.ProtoReflect.Descriptor instead.
 func (*TerminateSessionResponse) Descriptor() ([]byte, []int) {
-	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{13}
+	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *TerminateSessionResponse) GetSession() *Session {
@@ -934,7 +1014,7 @@ type SessionEvent struct {
 
 func (x *SessionEvent) Reset() {
 	*x = SessionEvent{}
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[14]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -946,7 +1026,7 @@ func (x *SessionEvent) String() string {
 func (*SessionEvent) ProtoMessage() {}
 
 func (x *SessionEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[14]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -959,7 +1039,7 @@ func (x *SessionEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionEvent.ProtoReflect.Descriptor instead.
 func (*SessionEvent) Descriptor() ([]byte, []int) {
-	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{14}
+	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SessionEvent) GetEventIndex() int64 {
@@ -1086,7 +1166,7 @@ type SessionStarted struct {
 
 func (x *SessionStarted) Reset() {
 	*x = SessionStarted{}
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[15]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1098,7 +1178,7 @@ func (x *SessionStarted) String() string {
 func (*SessionStarted) ProtoMessage() {}
 
 func (x *SessionStarted) ProtoReflect() protoreflect.Message {
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[15]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1111,7 +1191,7 @@ func (x *SessionStarted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionStarted.ProtoReflect.Descriptor instead.
 func (*SessionStarted) Descriptor() ([]byte, []int) {
-	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{15}
+	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *SessionStarted) GetSessionId() string {
@@ -1130,7 +1210,7 @@ type SessionOutput struct {
 
 func (x *SessionOutput) Reset() {
 	*x = SessionOutput{}
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[16]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1142,7 +1222,7 @@ func (x *SessionOutput) String() string {
 func (*SessionOutput) ProtoMessage() {}
 
 func (x *SessionOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[16]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1155,7 +1235,7 @@ func (x *SessionOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionOutput.ProtoReflect.Descriptor instead.
 func (*SessionOutput) Descriptor() ([]byte, []int) {
-	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{16}
+	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SessionOutput) GetData() []byte {
@@ -1173,7 +1253,7 @@ type SessionStdinClosed struct {
 
 func (x *SessionStdinClosed) Reset() {
 	*x = SessionStdinClosed{}
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[17]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1185,7 +1265,7 @@ func (x *SessionStdinClosed) String() string {
 func (*SessionStdinClosed) ProtoMessage() {}
 
 func (x *SessionStdinClosed) ProtoReflect() protoreflect.Message {
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[17]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1198,7 +1278,7 @@ func (x *SessionStdinClosed) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionStdinClosed.ProtoReflect.Descriptor instead.
 func (*SessionStdinClosed) Descriptor() ([]byte, []int) {
-	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{17}
+	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{19}
 }
 
 type SessionExited struct {
@@ -1210,7 +1290,7 @@ type SessionExited struct {
 
 func (x *SessionExited) Reset() {
 	*x = SessionExited{}
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[18]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1222,7 +1302,7 @@ func (x *SessionExited) String() string {
 func (*SessionExited) ProtoMessage() {}
 
 func (x *SessionExited) ProtoReflect() protoreflect.Message {
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[18]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1235,7 +1315,7 @@ func (x *SessionExited) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionExited.ProtoReflect.Descriptor instead.
 func (*SessionExited) Descriptor() ([]byte, []int) {
-	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{18}
+	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SessionExited) GetExitCode() int32 {
@@ -1255,7 +1335,7 @@ type SessionTerminated struct {
 
 func (x *SessionTerminated) Reset() {
 	*x = SessionTerminated{}
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[19]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1267,7 +1347,7 @@ func (x *SessionTerminated) String() string {
 func (*SessionTerminated) ProtoMessage() {}
 
 func (x *SessionTerminated) ProtoReflect() protoreflect.Message {
-	mi := &file_q15_exec_v1_execution_proto_msgTypes[19]
+	mi := &file_q15_exec_v1_execution_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1280,7 +1360,7 @@ func (x *SessionTerminated) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionTerminated.ProtoReflect.Descriptor instead.
 func (*SessionTerminated) Descriptor() ([]byte, []int) {
-	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{19}
+	return file_q15_exec_v1_execution_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *SessionTerminated) GetReason() string {
@@ -1349,7 +1429,10 @@ const file_q15_exec_v1_execution_proto_rawDesc = "" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\"D\n" +
 	"\x12GetSessionResponse\x12.\n" +
-	"\asession\x18\x01 \x01(\v2\x14.q15.exec.v1.SessionR\asession\"`\n" +
+	"\asession\x18\x01 \x01(\v2\x14.q15.exec.v1.SessionR\asession\"\x15\n" +
+	"\x13ListSessionsRequest\"H\n" +
+	"\x14ListSessionsResponse\x120\n" +
+	"\bsessions\x18\x01 \x03(\v2\x14.q15.exec.v1.SessionR\bsessions\"`\n" +
 	"\x13WatchSessionRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12*\n" +
@@ -1403,12 +1486,13 @@ const file_q15_exec_v1_execution_proto_rawDesc = "" +
 	"\x14SESSION_STATE_EXITED\x10\x03\x12\x1d\n" +
 	"\x19SESSION_STATE_TERMINATING\x10\x04\x12\x1c\n" +
 	"\x18SESSION_STATE_TERMINATED\x10\x05\x12\x18\n" +
-	"\x14SESSION_STATE_FAILED\x10\x062\xad\x04\n" +
+	"\x14SESSION_STATE_FAILED\x10\x062\x82\x05\n" +
 	"\x10ExecutionService\x12Y\n" +
 	"\x0eGetRuntimeInfo\x12\".q15.exec.v1.GetRuntimeInfoRequest\x1a#.q15.exec.v1.GetRuntimeInfoResponse\x12S\n" +
 	"\fStartSession\x12 .q15.exec.v1.StartSessionRequest\x1a!.q15.exec.v1.StartSessionResponse\x12M\n" +
 	"\n" +
-	"GetSession\x12\x1e.q15.exec.v1.GetSessionRequest\x1a\x1f.q15.exec.v1.GetSessionResponse\x12U\n" +
+	"GetSession\x12\x1e.q15.exec.v1.GetSessionRequest\x1a\x1f.q15.exec.v1.GetSessionResponse\x12S\n" +
+	"\fListSessions\x12 .q15.exec.v1.ListSessionsRequest\x1a!.q15.exec.v1.ListSessionsResponse\x12U\n" +
 	"\fWatchSession\x12 .q15.exec.v1.WatchSessionRequest\x1a!.q15.exec.v1.WatchSessionResponse0\x01\x12b\n" +
 	"\x11WriteSessionStdin\x12%.q15.exec.v1.WriteSessionStdinRequest\x1a&.q15.exec.v1.WriteSessionStdinResponse\x12_\n" +
 	"\x10TerminateSession\x12$.q15.exec.v1.TerminateSessionRequest\x1a%.q15.exec.v1.TerminateSessionResponseB7Z5github.com/q15co/q15/libs/exec-contract/execpb;execpbb\x06proto3"
@@ -1426,7 +1510,7 @@ func file_q15_exec_v1_execution_proto_rawDescGZIP() []byte {
 }
 
 var file_q15_exec_v1_execution_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_q15_exec_v1_execution_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_q15_exec_v1_execution_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_q15_exec_v1_execution_proto_goTypes = []any{
 	(SessionState)(0),                 // 0: q15.exec.v1.SessionState
 	(*GetRuntimeInfoRequest)(nil),     // 1: q15.exec.v1.GetRuntimeInfoRequest
@@ -1437,54 +1521,59 @@ var file_q15_exec_v1_execution_proto_goTypes = []any{
 	(*StartSessionResponse)(nil),      // 6: q15.exec.v1.StartSessionResponse
 	(*GetSessionRequest)(nil),         // 7: q15.exec.v1.GetSessionRequest
 	(*GetSessionResponse)(nil),        // 8: q15.exec.v1.GetSessionResponse
-	(*WatchSessionRequest)(nil),       // 9: q15.exec.v1.WatchSessionRequest
-	(*WatchSessionResponse)(nil),      // 10: q15.exec.v1.WatchSessionResponse
-	(*WriteSessionStdinRequest)(nil),  // 11: q15.exec.v1.WriteSessionStdinRequest
-	(*WriteSessionStdinResponse)(nil), // 12: q15.exec.v1.WriteSessionStdinResponse
-	(*TerminateSessionRequest)(nil),   // 13: q15.exec.v1.TerminateSessionRequest
-	(*TerminateSessionResponse)(nil),  // 14: q15.exec.v1.TerminateSessionResponse
-	(*SessionEvent)(nil),              // 15: q15.exec.v1.SessionEvent
-	(*SessionStarted)(nil),            // 16: q15.exec.v1.SessionStarted
-	(*SessionOutput)(nil),             // 17: q15.exec.v1.SessionOutput
-	(*SessionStdinClosed)(nil),        // 18: q15.exec.v1.SessionStdinClosed
-	(*SessionExited)(nil),             // 19: q15.exec.v1.SessionExited
-	(*SessionTerminated)(nil),         // 20: q15.exec.v1.SessionTerminated
-	(*timestamppb.Timestamp)(nil),     // 21: google.protobuf.Timestamp
+	(*ListSessionsRequest)(nil),       // 9: q15.exec.v1.ListSessionsRequest
+	(*ListSessionsResponse)(nil),      // 10: q15.exec.v1.ListSessionsResponse
+	(*WatchSessionRequest)(nil),       // 11: q15.exec.v1.WatchSessionRequest
+	(*WatchSessionResponse)(nil),      // 12: q15.exec.v1.WatchSessionResponse
+	(*WriteSessionStdinRequest)(nil),  // 13: q15.exec.v1.WriteSessionStdinRequest
+	(*WriteSessionStdinResponse)(nil), // 14: q15.exec.v1.WriteSessionStdinResponse
+	(*TerminateSessionRequest)(nil),   // 15: q15.exec.v1.TerminateSessionRequest
+	(*TerminateSessionResponse)(nil),  // 16: q15.exec.v1.TerminateSessionResponse
+	(*SessionEvent)(nil),              // 17: q15.exec.v1.SessionEvent
+	(*SessionStarted)(nil),            // 18: q15.exec.v1.SessionStarted
+	(*SessionOutput)(nil),             // 19: q15.exec.v1.SessionOutput
+	(*SessionStdinClosed)(nil),        // 20: q15.exec.v1.SessionStdinClosed
+	(*SessionExited)(nil),             // 21: q15.exec.v1.SessionExited
+	(*SessionTerminated)(nil),         // 22: q15.exec.v1.SessionTerminated
+	(*timestamppb.Timestamp)(nil),     // 23: google.protobuf.Timestamp
 }
 var file_q15_exec_v1_execution_proto_depIdxs = []int32{
 	2,  // 0: q15.exec.v1.GetRuntimeInfoResponse.capabilities:type_name -> q15.exec.v1.RuntimeCapability
 	0,  // 1: q15.exec.v1.Session.state:type_name -> q15.exec.v1.SessionState
-	21, // 2: q15.exec.v1.Session.started_at:type_name -> google.protobuf.Timestamp
-	21, // 3: q15.exec.v1.Session.finished_at:type_name -> google.protobuf.Timestamp
+	23, // 2: q15.exec.v1.Session.started_at:type_name -> google.protobuf.Timestamp
+	23, // 3: q15.exec.v1.Session.finished_at:type_name -> google.protobuf.Timestamp
 	4,  // 4: q15.exec.v1.StartSessionResponse.session:type_name -> q15.exec.v1.Session
 	4,  // 5: q15.exec.v1.GetSessionResponse.session:type_name -> q15.exec.v1.Session
-	15, // 6: q15.exec.v1.WatchSessionResponse.event:type_name -> q15.exec.v1.SessionEvent
-	4,  // 7: q15.exec.v1.WriteSessionStdinResponse.session:type_name -> q15.exec.v1.Session
-	4,  // 8: q15.exec.v1.TerminateSessionResponse.session:type_name -> q15.exec.v1.Session
-	21, // 9: q15.exec.v1.SessionEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	16, // 10: q15.exec.v1.SessionEvent.started:type_name -> q15.exec.v1.SessionStarted
-	17, // 11: q15.exec.v1.SessionEvent.stdout:type_name -> q15.exec.v1.SessionOutput
-	17, // 12: q15.exec.v1.SessionEvent.stderr:type_name -> q15.exec.v1.SessionOutput
-	18, // 13: q15.exec.v1.SessionEvent.stdin_closed:type_name -> q15.exec.v1.SessionStdinClosed
-	19, // 14: q15.exec.v1.SessionEvent.exited:type_name -> q15.exec.v1.SessionExited
-	20, // 15: q15.exec.v1.SessionEvent.terminated:type_name -> q15.exec.v1.SessionTerminated
-	1,  // 16: q15.exec.v1.ExecutionService.GetRuntimeInfo:input_type -> q15.exec.v1.GetRuntimeInfoRequest
-	5,  // 17: q15.exec.v1.ExecutionService.StartSession:input_type -> q15.exec.v1.StartSessionRequest
-	7,  // 18: q15.exec.v1.ExecutionService.GetSession:input_type -> q15.exec.v1.GetSessionRequest
-	9,  // 19: q15.exec.v1.ExecutionService.WatchSession:input_type -> q15.exec.v1.WatchSessionRequest
-	11, // 20: q15.exec.v1.ExecutionService.WriteSessionStdin:input_type -> q15.exec.v1.WriteSessionStdinRequest
-	13, // 21: q15.exec.v1.ExecutionService.TerminateSession:input_type -> q15.exec.v1.TerminateSessionRequest
-	3,  // 22: q15.exec.v1.ExecutionService.GetRuntimeInfo:output_type -> q15.exec.v1.GetRuntimeInfoResponse
-	6,  // 23: q15.exec.v1.ExecutionService.StartSession:output_type -> q15.exec.v1.StartSessionResponse
-	8,  // 24: q15.exec.v1.ExecutionService.GetSession:output_type -> q15.exec.v1.GetSessionResponse
-	10, // 25: q15.exec.v1.ExecutionService.WatchSession:output_type -> q15.exec.v1.WatchSessionResponse
-	12, // 26: q15.exec.v1.ExecutionService.WriteSessionStdin:output_type -> q15.exec.v1.WriteSessionStdinResponse
-	14, // 27: q15.exec.v1.ExecutionService.TerminateSession:output_type -> q15.exec.v1.TerminateSessionResponse
-	22, // [22:28] is the sub-list for method output_type
-	16, // [16:22] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	4,  // 6: q15.exec.v1.ListSessionsResponse.sessions:type_name -> q15.exec.v1.Session
+	17, // 7: q15.exec.v1.WatchSessionResponse.event:type_name -> q15.exec.v1.SessionEvent
+	4,  // 8: q15.exec.v1.WriteSessionStdinResponse.session:type_name -> q15.exec.v1.Session
+	4,  // 9: q15.exec.v1.TerminateSessionResponse.session:type_name -> q15.exec.v1.Session
+	23, // 10: q15.exec.v1.SessionEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	18, // 11: q15.exec.v1.SessionEvent.started:type_name -> q15.exec.v1.SessionStarted
+	19, // 12: q15.exec.v1.SessionEvent.stdout:type_name -> q15.exec.v1.SessionOutput
+	19, // 13: q15.exec.v1.SessionEvent.stderr:type_name -> q15.exec.v1.SessionOutput
+	20, // 14: q15.exec.v1.SessionEvent.stdin_closed:type_name -> q15.exec.v1.SessionStdinClosed
+	21, // 15: q15.exec.v1.SessionEvent.exited:type_name -> q15.exec.v1.SessionExited
+	22, // 16: q15.exec.v1.SessionEvent.terminated:type_name -> q15.exec.v1.SessionTerminated
+	1,  // 17: q15.exec.v1.ExecutionService.GetRuntimeInfo:input_type -> q15.exec.v1.GetRuntimeInfoRequest
+	5,  // 18: q15.exec.v1.ExecutionService.StartSession:input_type -> q15.exec.v1.StartSessionRequest
+	7,  // 19: q15.exec.v1.ExecutionService.GetSession:input_type -> q15.exec.v1.GetSessionRequest
+	9,  // 20: q15.exec.v1.ExecutionService.ListSessions:input_type -> q15.exec.v1.ListSessionsRequest
+	11, // 21: q15.exec.v1.ExecutionService.WatchSession:input_type -> q15.exec.v1.WatchSessionRequest
+	13, // 22: q15.exec.v1.ExecutionService.WriteSessionStdin:input_type -> q15.exec.v1.WriteSessionStdinRequest
+	15, // 23: q15.exec.v1.ExecutionService.TerminateSession:input_type -> q15.exec.v1.TerminateSessionRequest
+	3,  // 24: q15.exec.v1.ExecutionService.GetRuntimeInfo:output_type -> q15.exec.v1.GetRuntimeInfoResponse
+	6,  // 25: q15.exec.v1.ExecutionService.StartSession:output_type -> q15.exec.v1.StartSessionResponse
+	8,  // 26: q15.exec.v1.ExecutionService.GetSession:output_type -> q15.exec.v1.GetSessionResponse
+	10, // 27: q15.exec.v1.ExecutionService.ListSessions:output_type -> q15.exec.v1.ListSessionsResponse
+	12, // 28: q15.exec.v1.ExecutionService.WatchSession:output_type -> q15.exec.v1.WatchSessionResponse
+	14, // 29: q15.exec.v1.ExecutionService.WriteSessionStdin:output_type -> q15.exec.v1.WriteSessionStdinResponse
+	16, // 30: q15.exec.v1.ExecutionService.TerminateSession:output_type -> q15.exec.v1.TerminateSessionResponse
+	24, // [24:31] is the sub-list for method output_type
+	17, // [17:24] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_q15_exec_v1_execution_proto_init() }
@@ -1492,7 +1581,7 @@ func file_q15_exec_v1_execution_proto_init() {
 	if File_q15_exec_v1_execution_proto != nil {
 		return
 	}
-	file_q15_exec_v1_execution_proto_msgTypes[14].OneofWrappers = []any{
+	file_q15_exec_v1_execution_proto_msgTypes[16].OneofWrappers = []any{
 		(*SessionEvent_Started)(nil),
 		(*SessionEvent_Stdout)(nil),
 		(*SessionEvent_Stderr)(nil),
@@ -1506,7 +1595,7 @@ func file_q15_exec_v1_execution_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_q15_exec_v1_execution_proto_rawDesc), len(file_q15_exec_v1_execution_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   20,
+			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/libs/exec-contract/execpb/execution_grpc.pb.go
+++ b/libs/exec-contract/execpb/execution_grpc.pb.go
@@ -22,6 +22,7 @@ const (
 	ExecutionService_GetRuntimeInfo_FullMethodName    = "/q15.exec.v1.ExecutionService/GetRuntimeInfo"
 	ExecutionService_StartSession_FullMethodName      = "/q15.exec.v1.ExecutionService/StartSession"
 	ExecutionService_GetSession_FullMethodName        = "/q15.exec.v1.ExecutionService/GetSession"
+	ExecutionService_ListSessions_FullMethodName      = "/q15.exec.v1.ExecutionService/ListSessions"
 	ExecutionService_WatchSession_FullMethodName      = "/q15.exec.v1.ExecutionService/WatchSession"
 	ExecutionService_WriteSessionStdin_FullMethodName = "/q15.exec.v1.ExecutionService/WriteSessionStdin"
 	ExecutionService_TerminateSession_FullMethodName  = "/q15.exec.v1.ExecutionService/TerminateSession"
@@ -34,6 +35,7 @@ type ExecutionServiceClient interface {
 	GetRuntimeInfo(ctx context.Context, in *GetRuntimeInfoRequest, opts ...grpc.CallOption) (*GetRuntimeInfoResponse, error)
 	StartSession(ctx context.Context, in *StartSessionRequest, opts ...grpc.CallOption) (*StartSessionResponse, error)
 	GetSession(ctx context.Context, in *GetSessionRequest, opts ...grpc.CallOption) (*GetSessionResponse, error)
+	ListSessions(ctx context.Context, in *ListSessionsRequest, opts ...grpc.CallOption) (*ListSessionsResponse, error)
 	WatchSession(ctx context.Context, in *WatchSessionRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[WatchSessionResponse], error)
 	WriteSessionStdin(ctx context.Context, in *WriteSessionStdinRequest, opts ...grpc.CallOption) (*WriteSessionStdinResponse, error)
 	TerminateSession(ctx context.Context, in *TerminateSessionRequest, opts ...grpc.CallOption) (*TerminateSessionResponse, error)
@@ -71,6 +73,16 @@ func (c *executionServiceClient) GetSession(ctx context.Context, in *GetSessionR
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetSessionResponse)
 	err := c.cc.Invoke(ctx, ExecutionService_GetSession_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *executionServiceClient) ListSessions(ctx context.Context, in *ListSessionsRequest, opts ...grpc.CallOption) (*ListSessionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListSessionsResponse)
+	err := c.cc.Invoke(ctx, ExecutionService_ListSessions_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -123,6 +135,7 @@ type ExecutionServiceServer interface {
 	GetRuntimeInfo(context.Context, *GetRuntimeInfoRequest) (*GetRuntimeInfoResponse, error)
 	StartSession(context.Context, *StartSessionRequest) (*StartSessionResponse, error)
 	GetSession(context.Context, *GetSessionRequest) (*GetSessionResponse, error)
+	ListSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error)
 	WatchSession(*WatchSessionRequest, grpc.ServerStreamingServer[WatchSessionResponse]) error
 	WriteSessionStdin(context.Context, *WriteSessionStdinRequest) (*WriteSessionStdinResponse, error)
 	TerminateSession(context.Context, *TerminateSessionRequest) (*TerminateSessionResponse, error)
@@ -144,6 +157,9 @@ func (UnimplementedExecutionServiceServer) StartSession(context.Context, *StartS
 }
 func (UnimplementedExecutionServiceServer) GetSession(context.Context, *GetSessionRequest) (*GetSessionResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetSession not implemented")
+}
+func (UnimplementedExecutionServiceServer) ListSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListSessions not implemented")
 }
 func (UnimplementedExecutionServiceServer) WatchSession(*WatchSessionRequest, grpc.ServerStreamingServer[WatchSessionResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method WatchSession not implemented")
@@ -229,6 +245,24 @@ func _ExecutionService_GetSession_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ExecutionService_ListSessions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListSessionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ExecutionServiceServer).ListSessions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ExecutionService_ListSessions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ExecutionServiceServer).ListSessions(ctx, req.(*ListSessionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ExecutionService_WatchSession_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(WatchSessionRequest)
 	if err := stream.RecvMsg(m); err != nil {
@@ -294,6 +328,10 @@ var ExecutionService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetSession",
 			Handler:    _ExecutionService_GetSession_Handler,
+		},
+		{
+			MethodName: "ListSessions",
+			Handler:    _ExecutionService_ListSessions_Handler,
 		},
 		{
 			MethodName: "WriteSessionStdin",

--- a/libs/exec-contract/proto/q15/exec/v1/execution.proto
+++ b/libs/exec-contract/proto/q15/exec/v1/execution.proto
@@ -10,6 +10,7 @@ service ExecutionService {
   rpc GetRuntimeInfo(GetRuntimeInfoRequest) returns (GetRuntimeInfoResponse);
   rpc StartSession(StartSessionRequest) returns (StartSessionResponse);
   rpc GetSession(GetSessionRequest) returns (GetSessionResponse);
+  rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse);
   rpc WatchSession(WatchSessionRequest) returns (stream WatchSessionResponse);
   rpc WriteSessionStdin(WriteSessionStdinRequest) returns (WriteSessionStdinResponse);
   rpc TerminateSession(TerminateSessionRequest) returns (TerminateSessionResponse);
@@ -76,6 +77,12 @@ message GetSessionRequest {
 
 message GetSessionResponse {
   Session session = 1;
+}
+
+message ListSessionsRequest {}
+
+message ListSessionsResponse {
+  repeated Session sessions = 1;
 }
 
 message WatchSessionRequest {

--- a/systems/agent/internal/app/bot.go
+++ b/systems/agent/internal/app/bot.go
@@ -226,6 +226,7 @@ func buildToolList(
 		tools.NewApplyPatch(fileExec),
 		tools.NewValidateSkill(skillManager),
 		tools.NewExec(execClient),
+		tools.NewExecList(execClient),
 		tools.NewExecRead(execClient),
 		tools.NewExecWrite(execClient),
 		tools.NewExecKill(execClient),

--- a/systems/agent/internal/app/bot_prompt_test.go
+++ b/systems/agent/internal/app/bot_prompt_test.go
@@ -129,6 +129,7 @@ func TestBuildToolListIncludesOnlyCurrentRuntimeTools(t *testing.T) {
 		"apply_patch",
 		"validate_skill",
 		"exec",
+		"exec_list",
 		"exec_read",
 		"exec_write",
 		"exec_kill",
@@ -174,6 +175,7 @@ func TestBuildToolListAppendsWebSearchWhenConfigured(t *testing.T) {
 		"apply_patch",
 		"validate_skill",
 		"exec",
+		"exec_list",
 		"exec_read",
 		"exec_write",
 		"exec_kill",
@@ -220,6 +222,7 @@ func TestBuildToolListAppendsEmbeddingToolsWhenConfigured(t *testing.T) {
 		"apply_patch",
 		"validate_skill",
 		"exec",
+		"exec_list",
 		"exec_read",
 		"exec_write",
 		"exec_kill",
@@ -260,6 +263,13 @@ func (stubExecutionService) GetSession(
 	*execpb.GetSessionRequest,
 ) (*execpb.GetSessionResponse, error) {
 	return &execpb.GetSessionResponse{}, nil
+}
+
+func (stubExecutionService) ListSessions(
+	context.Context,
+	*execpb.ListSessionsRequest,
+) (*execpb.ListSessionsResponse, error) {
+	return &execpb.ListSessionsResponse{}, nil
 }
 
 func (stubExecutionService) WatchSession(

--- a/systems/agent/internal/execution/client.go
+++ b/systems/agent/internal/execution/client.go
@@ -26,6 +26,10 @@ type Service interface {
 		ctx context.Context,
 		req *execpb.GetSessionRequest,
 	) (*execpb.GetSessionResponse, error)
+	ListSessions(
+		ctx context.Context,
+		req *execpb.ListSessionsRequest,
+	) (*execpb.ListSessionsResponse, error)
 	WatchSession(ctx context.Context, req *execpb.WatchSessionRequest) (WatchStream, error)
 	WriteSessionStdin(
 		ctx context.Context,
@@ -96,6 +100,14 @@ func (c *Client) GetSession(
 	req *execpb.GetSessionRequest,
 ) (*execpb.GetSessionResponse, error) {
 	return c.client.GetSession(ctx, req)
+}
+
+// ListSessions returns snapshots for all tracked exec sessions.
+func (c *Client) ListSessions(
+	ctx context.Context,
+	req *execpb.ListSessionsRequest,
+) (*execpb.ListSessionsResponse, error) {
+	return c.client.ListSessions(ctx, req)
 }
 
 // WatchSession opens one event stream.

--- a/systems/agent/internal/tools/exec/exec_test.go
+++ b/systems/agent/internal/tools/exec/exec_test.go
@@ -16,12 +16,14 @@ import (
 type fakeExecClient struct {
 	startResp       *execpb.StartSessionResponse
 	getResp         *execpb.GetSessionResponse
+	listResp        *execpb.ListSessionsResponse
 	writeResp       *execpb.WriteSessionStdinResponse
 	terminateResp   *execpb.TerminateSessionResponse
 	watchEvents     []*execpb.WatchSessionResponse
 	watchErr        error
 	watchRecvErr    error
 	startReq        *execpb.StartSessionRequest
+	listReq         *execpb.ListSessionsRequest
 	watchReq        *execpb.WatchSessionRequest
 	writeReq        *execpb.WriteSessionStdinRequest
 	terminateReq    *execpb.TerminateSessionRequest
@@ -64,6 +66,17 @@ func (f *fakeExecClient) GetSession(
 			ExitCode:    0,
 		},
 	}, nil
+}
+
+func (f *fakeExecClient) ListSessions(
+	_ context.Context,
+	req *execpb.ListSessionsRequest,
+) (*execpb.ListSessionsResponse, error) {
+	f.listReq = req
+	if f.listResp != nil {
+		return f.listResp, nil
+	}
+	return &execpb.ListSessionsResponse{}, nil
 }
 
 func (f *fakeExecClient) WatchSession(
@@ -267,6 +280,13 @@ func (c *cancelAwareExecClient) GetSession(
 	return c.delegate.GetSession(ctx, req)
 }
 
+func (c *cancelAwareExecClient) ListSessions(
+	ctx context.Context,
+	req *execpb.ListSessionsRequest,
+) (*execpb.ListSessionsResponse, error) {
+	return c.delegate.ListSessions(ctx, req)
+}
+
 func (c *cancelAwareExecClient) WatchSession(
 	ctx context.Context,
 	_ *execpb.WatchSessionRequest,
@@ -408,6 +428,234 @@ func TestExecRunWaitZeroReturnsImmediately(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("output missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestExecListRunFormatsKnownSessions(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeExecClient{
+		listResp: &execpb.ListSessionsResponse{
+			Sessions: []*execpb.Session{
+				{
+					SessionId:      "sess-1",
+					Command:        "sleep 60",
+					Packages:       []string{"nixpkgs#bash"},
+					WorkingDir:     "/workspace",
+					StdinOpen:      true,
+					State:          execpb.SessionState_SESSION_STATE_RUNNING,
+					NextEventIndex: 3,
+					StartedAt:      timestamppb.New(time.Now().Add(-2 * time.Second)),
+				},
+				{
+					SessionId:         "sess-2",
+					Command:           "false",
+					State:             execpb.SessionState_SESSION_STATE_EXITED,
+					HasExitCode:       true,
+					ExitCode:          1,
+					TerminationReason: "non-zero exit",
+				},
+			},
+		},
+	}
+
+	out, err := NewList(client).Run(context.Background(), `{}`)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if client.listReq == nil {
+		t.Fatalf("expected ListSessions request")
+	}
+	for _, want := range []string{
+		"Sessions: 1 running, 1 exited (2 total, 2 shown)",
+		"--- Session 1 ---",
+		"Session-ID: sess-1",
+		"State: running",
+		"Command: sleep 60",
+		"Working-Dir: /workspace",
+		"Packages: nixpkgs#bash",
+		"Stdin-Open: true",
+		"Next-Event-Index: 3",
+		"Session-Age-Seconds:",
+		"--- Session 2 ---",
+		"Session-ID: sess-2",
+		"State: exited",
+		"Exit-Code: 1",
+		"Termination-Reason: non-zero exit",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestExecListRunFiltersByState(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeExecClient{
+		listResp: &execpb.ListSessionsResponse{
+			Sessions: []*execpb.Session{
+				{
+					SessionId: "sess-running",
+					Command:   "sleep 60",
+					State:     execpb.SessionState_SESSION_STATE_RUNNING,
+				},
+				{
+					SessionId:   "sess-exited",
+					Command:     "true",
+					State:       execpb.SessionState_SESSION_STATE_EXITED,
+					HasExitCode: true,
+					ExitCode:    0,
+				},
+				{
+					SessionId:         "sess-killed",
+					Command:           "sleep 600",
+					State:             execpb.SessionState_SESSION_STATE_TERMINATED,
+					TerminationReason: "terminate requested",
+				},
+			},
+		},
+	}
+
+	out, err := NewList(client).Run(context.Background(), `{"state":"running"}`)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	for _, want := range []string{
+		"Sessions: 1 running, 1 exited, 1 terminated (3 total, 1 shown, filter: running)",
+		"Session-ID: sess-running",
+		"State: running",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+	for _, unwanted := range []string{
+		"Session-ID: sess-exited",
+		"Session-ID: sess-killed",
+	} {
+		if strings.Contains(out, unwanted) {
+			t.Fatalf("output contains %q despite running filter:\n%s", unwanted, out)
+		}
+	}
+}
+
+func TestExecListRunTruncatesLongCommandsByDefault(t *testing.T) {
+	t.Parallel()
+
+	command := "python -c " + strings.Repeat("x", defaultCommandChars+25)
+	client := &fakeExecClient{
+		listResp: &execpb.ListSessionsResponse{
+			Sessions: []*execpb.Session{
+				{
+					SessionId: "sess-long",
+					Command:   command,
+					State:     execpb.SessionState_SESSION_STATE_RUNNING,
+				},
+			},
+		},
+	}
+
+	out, err := NewList(client).Run(context.Background(), `{}`)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(out, "Command: python -c ") {
+		t.Fatalf("output missing command prefix:\n%s", out)
+	}
+	if !strings.Contains(out, "...") {
+		t.Fatalf("output missing truncation suffix:\n%s", out)
+	}
+	if strings.Contains(out, strings.Repeat("x", defaultCommandChars+20)) {
+		t.Fatalf("output contains untruncated command:\n%s", out)
+	}
+}
+
+func TestExecListRunCanRaiseCommandLengthLimit(t *testing.T) {
+	t.Parallel()
+
+	command := "python -c " + strings.Repeat("x", defaultCommandChars+25)
+	client := &fakeExecClient{
+		listResp: &execpb.ListSessionsResponse{
+			Sessions: []*execpb.Session{
+				{
+					SessionId: "sess-long",
+					Command:   command,
+					State:     execpb.SessionState_SESSION_STATE_RUNNING,
+				},
+			},
+		},
+	}
+
+	out, err := NewList(client).Run(
+		context.Background(),
+		`{"max_command_chars":500}`,
+	)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(out, "Command: "+command) {
+		t.Fatalf("output missing full command:\n%s", out)
+	}
+}
+
+func TestExecListRunAppliesLimit(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeExecClient{
+		listResp: &execpb.ListSessionsResponse{
+			Sessions: []*execpb.Session{
+				{SessionId: "sess-1", State: execpb.SessionState_SESSION_STATE_RUNNING},
+				{SessionId: "sess-2", State: execpb.SessionState_SESSION_STATE_RUNNING},
+				{SessionId: "sess-3", State: execpb.SessionState_SESSION_STATE_EXITED},
+			},
+		},
+	}
+
+	out, err := NewList(client).Run(context.Background(), `{"limit":2}`)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	for _, want := range []string{
+		"Sessions: 2 running, 1 exited (3 total, 2 shown, 1 omitted by limit)",
+		"Session-ID: sess-1",
+		"Session-ID: sess-2",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Session-ID: sess-3") {
+		t.Fatalf("output contains limited session:\n%s", out)
+	}
+}
+
+func TestExecListRunRejectsInvalidOptions(t *testing.T) {
+	t.Parallel()
+
+	tool := NewList(&fakeExecClient{})
+	for _, args := range []string{
+		`{"state":"alive"}`,
+		`{"limit":-1}`,
+		`{"max_command_chars":0}`,
+		`{"unknown":true}`,
+	} {
+		_, err := tool.Run(context.Background(), args)
+		if err == nil {
+			t.Fatalf("Run(%s) error = nil, want validation error", args)
+		}
+	}
+}
+
+func TestExecListRunHandlesNoSessions(t *testing.T) {
+	t.Parallel()
+
+	out, err := NewList(&fakeExecClient{}).Run(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if out != "Sessions: 0 total, 0 shown" {
+		t.Fatalf("output = %q, want Sessions: 0 total, 0 shown", out)
 	}
 }
 

--- a/systems/agent/internal/tools/exec/session_tools.go
+++ b/systems/agent/internal/tools/exec/session_tools.go
@@ -22,9 +22,113 @@ const (
 	maxExecWaitSeconds      = 300
 	defaultMaxOutputChars   = 20000
 	maxOutputCharsLimit     = 200000
+	defaultListLimit        = 100
+	maxListLimit            = 500
+	defaultCommandChars     = 200
+	maxCommandCharsLimit    = 5000
 	readSessionWatchTimeout = time.Second
 	finalDrainTimeout       = 100 * time.Millisecond
 )
+
+// List enumerates tracked exec sessions.
+type List struct {
+	client execution.Service
+}
+
+// NewList constructs an exec_list tool backed by the provided session client.
+func NewList(client execution.Service) *List {
+	return &List{client: client}
+}
+
+// Definition returns the tool schema exposed to the model.
+func (l *List) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name:        "exec_list",
+		Description: "List all tracked exec sessions known to the execution service",
+		PromptGuidance: []string{
+			"Use to discover running, orphaned, or recently finished exec sessions when the session ID is not in context.",
+			"Use state running to focus on live sessions; leave state as all when you need the full session history.",
+			"Commands are truncated by default for readability; raise max_command_chars only when the command text itself matters.",
+			"Use returned Session-ID values with exec_read, exec_write, or exec_kill.",
+		},
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"state": map[string]any{
+					"type": "string",
+					"enum": []string{
+						"all",
+						"active",
+						"terminal",
+						"starting",
+						"running",
+						"terminating",
+						"exited",
+						"terminated",
+						"failed",
+					},
+					"default": "all",
+				},
+				"limit": map[string]any{
+					"type":    "integer",
+					"minimum": 0,
+					"maximum": maxListLimit,
+					"default": defaultListLimit,
+				},
+				"max_command_chars": map[string]any{
+					"type":    "integer",
+					"minimum": 1,
+					"maximum": maxCommandCharsLimit,
+					"default": defaultCommandChars,
+				},
+			},
+			"additionalProperties": false,
+		},
+	}
+}
+
+// Run lists all sessions from raw JSON arguments.
+func (l *List) Run(ctx context.Context, arguments string) (string, error) {
+	arguments = strings.TrimSpace(arguments)
+	if arguments == "" {
+		arguments = "{}"
+	}
+	var args struct {
+		State           string `json:"state"`
+		Limit           *int   `json:"limit"`
+		MaxCommandChars *int   `json:"max_command_chars"`
+	}
+	dec := json.NewDecoder(strings.NewReader(arguments))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&args); err != nil {
+		return "", fmt.Errorf("invalid arguments JSON: %w", err)
+	}
+	stateFilter, err := normalizeListStateFilter(args.State)
+	if err != nil {
+		return "", err
+	}
+	limit, err := normalizeListLimit(args.Limit)
+	if err != nil {
+		return "", err
+	}
+	maxCommandChars, err := normalizeCommandChars(args.MaxCommandChars)
+	if err != nil {
+		return "", err
+	}
+	if l.client == nil {
+		return "", fmt.Errorf("no exec service client configured")
+	}
+
+	resp, err := l.client.ListSessions(ctx, &execpb.ListSessionsRequest{})
+	if err != nil {
+		return "", fmt.Errorf("list exec sessions: %w", err)
+	}
+	return formatSessionListResult(resp.GetSessions(), sessionListOptions{
+		StateFilter:     stateFilter,
+		Limit:           limit,
+		MaxCommandChars: maxCommandChars,
+	}), nil
+}
 
 // Read polls output and state from an existing exec session.
 type Read struct {
@@ -551,6 +655,240 @@ type sessionToolResult struct {
 	Stderr        string
 }
 
+type sessionListOptions struct {
+	StateFilter     listStateFilter
+	Limit           int
+	MaxCommandChars int
+}
+
+type listStateFilter string
+
+const (
+	listStateFilterAll         listStateFilter = "all"
+	listStateFilterActive      listStateFilter = "active"
+	listStateFilterTerminal    listStateFilter = "terminal"
+	listStateFilterStarting    listStateFilter = "starting"
+	listStateFilterRunning     listStateFilter = "running"
+	listStateFilterTerminating listStateFilter = "terminating"
+	listStateFilterExited      listStateFilter = "exited"
+	listStateFilterTerminated  listStateFilter = "terminated"
+	listStateFilterFailed      listStateFilter = "failed"
+)
+
+func formatSessionListResult(sessions []*execpb.Session, opts sessionListOptions) string {
+	nonNilSessions := make([]*execpb.Session, 0, len(sessions))
+	for _, session := range sessions {
+		if session != nil {
+			nonNilSessions = append(nonNilSessions, session)
+		}
+	}
+
+	filtered := filterSessions(nonNilSessions, opts.StateFilter)
+	shown := limitedSessions(filtered, opts.Limit)
+	omitted := len(filtered) - len(shown)
+
+	lines := []string{formatSessionListSummary(
+		nonNilSessions,
+		len(shown),
+		opts.StateFilter,
+		omitted,
+	)}
+	for i, session := range shown {
+		lines = append(lines, fmt.Sprintf("--- Session %d ---", i+1))
+		lines = append(lines, "Session-ID: "+session.GetSessionId())
+		lines = append(lines, "State: "+formatSessionState(session.GetState()))
+		if command := strings.TrimSpace(session.GetCommand()); command != "" {
+			lines = append(
+				lines,
+				"Command: "+truncateCommand(singleLine(command), opts.MaxCommandChars),
+			)
+		}
+		if workingDir := strings.TrimSpace(session.GetWorkingDir()); workingDir != "" {
+			lines = append(lines, "Working-Dir: "+workingDir)
+		}
+		if packages := session.GetPackages(); len(packages) > 0 {
+			lines = append(lines, "Packages: "+strings.Join(packages, ", "))
+		}
+		lines = append(lines, fmt.Sprintf("Stdin-Open: %t", session.GetStdinOpen()))
+		lines = append(lines, fmt.Sprintf("Next-Event-Index: %d", session.GetNextEventIndex()))
+		if age, ok := sessionAgeSeconds(session); ok {
+			lines = append(lines, fmt.Sprintf("Session-Age-Seconds: %d", age))
+		}
+		if session.GetHasExitCode() {
+			lines = append(lines, fmt.Sprintf("Exit-Code: %d", session.GetExitCode()))
+		}
+		if reason := strings.TrimSpace(session.GetTerminationReason()); reason != "" {
+			lines = append(lines, "Termination-Reason: "+singleLine(reason))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func normalizeListStateFilter(value string) (listStateFilter, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return listStateFilterAll, nil
+	}
+	filter := listStateFilter(value)
+	switch filter {
+	case listStateFilterAll,
+		listStateFilterActive,
+		listStateFilterTerminal,
+		listStateFilterStarting,
+		listStateFilterRunning,
+		listStateFilterTerminating,
+		listStateFilterExited,
+		listStateFilterTerminated,
+		listStateFilterFailed:
+		return filter, nil
+	default:
+		return "", fmt.Errorf(
+			"state must be one of: all, active, terminal, starting, running, terminating, exited, terminated, failed",
+		)
+	}
+}
+
+func normalizeListLimit(value *int) (int, error) {
+	if value == nil {
+		return defaultListLimit, nil
+	}
+	if *value < 0 {
+		return 0, fmt.Errorf("limit must be >= 0")
+	}
+	if *value > maxListLimit {
+		return 0, fmt.Errorf("limit must be <= %d", maxListLimit)
+	}
+	return *value, nil
+}
+
+func normalizeCommandChars(value *int) (int, error) {
+	if value == nil {
+		return defaultCommandChars, nil
+	}
+	if *value < 1 {
+		return 0, fmt.Errorf("max_command_chars must be >= 1")
+	}
+	if *value > maxCommandCharsLimit {
+		return 0, fmt.Errorf("max_command_chars must be <= %d", maxCommandCharsLimit)
+	}
+	return *value, nil
+}
+
+func filterSessions(sessions []*execpb.Session, filter listStateFilter) []*execpb.Session {
+	if filter == "" {
+		filter = listStateFilterAll
+	}
+	out := make([]*execpb.Session, 0, len(sessions))
+	for _, session := range sessions {
+		if sessionMatchesFilter(session, filter) {
+			out = append(out, session)
+		}
+	}
+	return out
+}
+
+func limitedSessions(sessions []*execpb.Session, limit int) []*execpb.Session {
+	if limit < 0 || limit >= len(sessions) {
+		return sessions
+	}
+	return sessions[:limit]
+}
+
+func sessionMatchesFilter(session *execpb.Session, filter listStateFilter) bool {
+	if session == nil {
+		return false
+	}
+	state := session.GetState()
+	switch filter {
+	case listStateFilterAll:
+		return true
+	case listStateFilterActive:
+		return !isTerminalSession(session)
+	case listStateFilterTerminal:
+		return isTerminalSession(session)
+	case listStateFilterStarting:
+		return state == execpb.SessionState_SESSION_STATE_STARTING
+	case listStateFilterRunning:
+		return state == execpb.SessionState_SESSION_STATE_RUNNING
+	case listStateFilterTerminating:
+		return state == execpb.SessionState_SESSION_STATE_TERMINATING
+	case listStateFilterExited:
+		return state == execpb.SessionState_SESSION_STATE_EXITED
+	case listStateFilterTerminated:
+		return state == execpb.SessionState_SESSION_STATE_TERMINATED
+	case listStateFilterFailed:
+		return state == execpb.SessionState_SESSION_STATE_FAILED
+	default:
+		return true
+	}
+}
+
+func formatSessionListSummary(
+	sessions []*execpb.Session,
+	shown int,
+	filter listStateFilter,
+	omitted int,
+) string {
+	total := len(sessions)
+	if filter == "" {
+		filter = listStateFilterAll
+	}
+	if total == 0 {
+		if filter == listStateFilterAll {
+			return "Sessions: 0 total, 0 shown"
+		}
+		return fmt.Sprintf("Sessions: 0 total, 0 shown (filter: %s)", filter)
+	}
+	stateParts := sessionStateSummaryParts(sessions)
+
+	suffix := fmt.Sprintf("(%d total, %d shown", total, shown)
+	if filter != listStateFilterAll {
+		suffix += fmt.Sprintf(", filter: %s", filter)
+	}
+	if omitted > 0 {
+		suffix += fmt.Sprintf(", %d omitted by limit", omitted)
+	}
+	suffix += ")"
+	return "Sessions: " + strings.Join(stateParts, ", ") + " " + suffix
+}
+
+func sessionStateSummaryParts(sessions []*execpb.Session) []string {
+	counts := map[execpb.SessionState]int{}
+	for _, session := range sessions {
+		if session == nil {
+			continue
+		}
+		counts[session.GetState()]++
+	}
+
+	orderedStates := []execpb.SessionState{
+		execpb.SessionState_SESSION_STATE_STARTING,
+		execpb.SessionState_SESSION_STATE_RUNNING,
+		execpb.SessionState_SESSION_STATE_TERMINATING,
+		execpb.SessionState_SESSION_STATE_EXITED,
+		execpb.SessionState_SESSION_STATE_TERMINATED,
+		execpb.SessionState_SESSION_STATE_FAILED,
+		execpb.SessionState_SESSION_STATE_UNSPECIFIED,
+	}
+	parts := make([]string, 0, len(orderedStates))
+	for _, state := range orderedStates {
+		if count := counts[state]; count > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", count, formatSessionState(state)))
+		}
+	}
+	return parts
+}
+
+func truncateCommand(command string, maxChars int) string {
+	if maxChars <= 0 || len(command) <= maxChars {
+		return command
+	}
+	if maxChars <= 3 {
+		return command[:maxChars]
+	}
+	return command[:maxChars-3] + "..."
+}
+
 func formatSessionToolResult(result sessionToolResult) string {
 	lines := make([]string, 0, 12)
 	lines = append(lines, "Session-ID: "+result.SessionID)
@@ -620,4 +958,8 @@ func sessionAgeSeconds(session *execpb.Session) (int64, bool) {
 		return 0, true
 	}
 	return int64(age.Seconds()), true
+}
+
+func singleLine(value string) string {
+	return strings.Join(strings.Fields(value), " ")
 }

--- a/systems/agent/internal/tools/registry.go
+++ b/systems/agent/internal/tools/registry.go
@@ -47,6 +47,11 @@ func NewExec(client execution.Service) *exec.Exec {
 	return exec.NewExec(client)
 }
 
+// NewExecList delegates to exec.NewList.
+func NewExecList(client execution.Service) *exec.List {
+	return exec.NewList(client)
+}
+
 // NewExecRead delegates to exec.NewRead.
 func NewExecRead(client execution.Service) *exec.Read {
 	return exec.NewRead(client)

--- a/systems/exec/internal/service/grpc.go
+++ b/systems/exec/internal/service/grpc.go
@@ -68,6 +68,7 @@ func (s *GRPCServer) GetRuntimeInfo(
 		ProxyPolicyRevision: s.info.ProxyPolicyRevision,
 		Capabilities: []*execpb.RuntimeCapability{
 			{Name: "sessions", Enabled: true},
+			{Name: "list_sessions", Enabled: true},
 			{Name: "watch", Enabled: true},
 			{Name: "stdin", Enabled: true},
 			{Name: "terminate", Enabled: true},
@@ -109,6 +110,17 @@ func (s *GRPCServer) GetSession(
 		return nil, mapError(err)
 	}
 	return &execpb.GetSessionResponse{Session: session}, nil
+}
+
+// ListSessions returns current snapshots for all tracked sessions.
+func (s *GRPCServer) ListSessions(
+	_ context.Context,
+	req *execpb.ListSessionsRequest,
+) (*execpb.ListSessionsResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	return &execpb.ListSessionsResponse{Sessions: s.manager.ListSessions()}, nil
 }
 
 // WatchSession streams session events from the requested cursor.

--- a/systems/exec/internal/service/grpc_test.go
+++ b/systems/exec/internal/service/grpc_test.go
@@ -84,6 +84,17 @@ func TestGRPCServerRunsSessionsEndToEnd(t *testing.T) {
 		t.Fatalf("StartSession() error = %v", err)
 	}
 
+	listed, err := client.ListSessions(ctx, &execpb.ListSessionsRequest{})
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if got := len(listed.GetSessions()); got != 1 {
+		t.Fatalf("ListSessions() returned %d sessions, want 1", got)
+	}
+	if got := listed.GetSessions()[0].GetSessionId(); got != started.GetSession().GetSessionId() {
+		t.Fatalf("listed session id = %q, want %q", got, started.GetSession().GetSessionId())
+	}
+
 	watch, err := client.WatchSession(ctx, &execpb.WatchSessionRequest{
 		SessionId: started.GetSession().GetSessionId(),
 	})

--- a/systems/exec/internal/service/manager.go
+++ b/systems/exec/internal/service/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -150,6 +151,25 @@ func (m *Manager) GetSession(sessionID string) (*execpb.Session, error) {
 		return nil, err
 	}
 	return session.snapshot(), nil
+}
+
+// ListSessions returns current snapshots for all tracked sessions.
+func (m *Manager) ListSessions() []*execpb.Session {
+	m.mu.RLock()
+	sessions := make([]*managedSession, 0, len(m.sessions))
+	for _, session := range m.sessions {
+		sessions = append(sessions, session)
+	}
+	m.mu.RUnlock()
+
+	snapshots := make([]*execpb.Session, 0, len(sessions))
+	for _, session := range sessions {
+		snapshots = append(snapshots, session.snapshot())
+	}
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].GetSessionId() < snapshots[j].GetSessionId()
+	})
+	return snapshots
 }
 
 // WatchSession returns all events after the provided cursor and blocks until completion.

--- a/systems/exec/internal/service/manager_test.go
+++ b/systems/exec/internal/service/manager_test.go
@@ -31,6 +31,42 @@ func TestManagerSupportsConcurrentSessions(t *testing.T) {
 	}
 }
 
+func TestManagerListSessionsReturnsSnapshots(t *testing.T) {
+	t.Parallel()
+
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	first, err := manager.StartSession(ctx, "printf first", []string{"ignored"}, "", false)
+	if err != nil {
+		t.Fatalf("StartSession(first) error = %v", err)
+	}
+	second, err := manager.StartSession(ctx, "sleep 10", []string{"ignored"}, "", false)
+	if err != nil {
+		t.Fatalf("StartSession(second) error = %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = manager.TerminateSession(second.GetSessionId(), true)
+	})
+
+	sessions := manager.ListSessions()
+	if len(sessions) != 2 {
+		t.Fatalf("ListSessions() returned %d sessions, want 2", len(sessions))
+	}
+	if got := sessions[0].GetSessionId(); got != first.GetSessionId() {
+		t.Fatalf("first listed session = %q, want %q", got, first.GetSessionId())
+	}
+	if got := sessions[1].GetSessionId(); got != second.GetSessionId() {
+		t.Fatalf("second listed session = %q, want %q", got, second.GetSessionId())
+	}
+	if got := sessions[0].GetCommand(); got != "printf first" {
+		t.Fatalf("first command = %q, want printf first", got)
+	}
+	if got := sessions[1].GetState(); got != execpb.SessionState_SESSION_STATE_RUNNING {
+		t.Fatalf("second state = %v, want running", got)
+	}
+}
+
 func TestManagerWatchSessionReplaysFromCursor(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add the `ListSessions` exec service RPC and generated Go bindings.
- Wire session listing through the exec manager, gRPC server, and agent execution client.
- Add the `exec_list` tool so agents can discover active and completed exec sessions.
- Improve `exec_list` ergonomics with state filtering, command truncation, state-aware summaries, and a defensive result limit.

Closes #89.

## Validation

- `make fmt FILES='systems/agent/internal/tools/exec/session_tools.go systems/agent/internal/tools/exec/exec_test.go'`
- `make lint-changed FILES='systems/agent/internal/tools/exec/session_tools.go systems/agent/internal/tools/exec/exec_test.go'`
- `cd systems/agent && CGO_ENABLED=0 go test ./internal/tools/exec`
- `make verify`