### PR TITLE
fix(exec): install fontconfig and fonts for headless browser screenshots

### DIFF
--- a/docker/exec.Dockerfile
+++ b/docker/exec.Dockerfile
@@ -15,13 +15,16 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 FROM nixos/nix:latest
 
-RUN nix --extra-experimental-features 'nix-command flakes' build --no-link nixpkgs#tzdata && \
+RUN nix --extra-experimental-features 'nix-command flakes' build --no-link nixpkgs#tzdata nixpkgs#fontconfig nixpkgs#dejavu_fonts && \
     TZDATA_PATH="$(nix --extra-experimental-features 'nix-command flakes' eval --raw nixpkgs#tzdata.outPath)" && \
-    mkdir -p /etc /var/lib/q15/bootstrap-nix && \
+    FONTCONFIG_PATH="$(nix --extra-experimental-features 'nix-command flakes' eval --raw nixpkgs#fontconfig.outPath)" && \
+    mkdir -p /etc/zoneinfo /etc/fonts /var/lib/q15/bootstrap-nix && \
     ln -sfn "${TZDATA_PATH}/share/zoneinfo" /etc/zoneinfo && \
+    ln -sfn "${FONTCONFIG_PATH}/etc/fonts/fonts.conf" /etc/fonts/fonts.conf && \
     cp -al /nix/. /var/lib/q15/bootstrap-nix/
 
 ENV TZDIR=/etc/zoneinfo
+ENV FONTCONFIG_FILE=/etc/fonts/fonts.conf
 
 COPY --from=build /out/q15-exec /usr/local/bin/q15-exec
 


### PR DESCRIPTION
Pre-install fontconfig and dejavu_fonts into the exec image, symlink /etc/fonts/fonts.conf, and set FONTCONFIG_FILE so Chromium can render text in screenshots and PDFs.